### PR TITLE
Stamp one version into both places that carry it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
         with:
           global-json-file: global.json
 
+      # The binary bakes its version in at compile time, so this has to happen
+      # before the build rather than alongside the bundling.
+      - name: Stamp version
+        if: inputs.version != ''
+        shell: bash
+        run: node scripts/stamp-version.mjs "${{ inputs.version }}"
+
       - name: Build
         shell: bash
         run: ./scripts/build.sh "${{ matrix.rid }}"
@@ -78,15 +85,7 @@ jobs:
 
       - name: Stamp version
         if: inputs.version != ''
-        run: |
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            pkg.version = process.env.VERSION;
-            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-          '
-        env:
-          VERSION: ${{ inputs.version }}
+        run: node scripts/stamp-version.mjs "${{ inputs.version }}"
 
       # bundle.mjs merges into the existing manifest, so bundling each downloaded
       # architecture in turn produces one manifest covering all of them.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-canvas",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "View, create, boot, and interact with local iOS simulators and Android emulators from a GitHub Copilot canvas.",
   "main": "extension.mjs",
   "type": "module",

--- a/scripts/stamp-version.mjs
+++ b/scripts/stamp-version.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Writes one version into the two places that carry it: package.json, which is
+// the version the plugin manager shows, and Directory.Build.props, which is what
+// the binary reports from `mobile-canvas --version`. They are separate files and
+// drift apart silently, so a bug report ends up naming a version that never
+// shipped. The release workflow runs this before building rather than only
+// before bundling, because the binary bakes its version in at compile time.
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const version = process.argv[2];
+if (!version) {
+  console.error("usage: stamp-version.mjs <version>");
+  process.exit(1);
+}
+
+// NuGet splits a version at the first hyphen: everything before is the numeric
+// prefix, everything after is the prerelease suffix.
+const match = /^(\d+\.\d+\.\d+)(?:-(.+))?$/.exec(version);
+if (!match) {
+  console.error(`not a version: ${version} (expected 1.2.3 or 1.2.3-preview.1)`);
+  process.exit(1);
+}
+const [, prefix, suffix = ""] = match;
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const pkgPath = join(root, "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+pkg.version = version;
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+const propsPath = join(root, "Directory.Build.props");
+const before = readFileSync(propsPath, "utf8");
+const after = before
+  .replace(/<VersionPrefix>[^<]*<\/VersionPrefix>/, `<VersionPrefix>${prefix}</VersionPrefix>`)
+  .replace(/<VersionSuffix>[^<]*<\/VersionSuffix>/, `<VersionSuffix>${suffix}</VersionSuffix>`);
+if (after === before) {
+  console.error(`Directory.Build.props has no version to replace`);
+  process.exit(1);
+}
+writeFileSync(propsPath, after);
+
+console.log(`stamped ${version} into package.json and Directory.Build.props`);


### PR DESCRIPTION
The plugin version (`package.json`) and the binary's own version
(`Directory.Build.props`) drifted apart, so `mobile-canvas --version` reported
`0.1.0-preview.1` while the plugin called itself `0.1.1`.

`scripts/stamp-version.mjs` writes both. The release workflow now runs it in the
build job as well as the bundle job, since the binary bakes its version in at
compile time and stamping only before bundling comes too late for it.
