### PR TITLE
Make the runtimes drift check able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,15 @@ jobs:
       - name: Verify bundled runtimes
         run: node scripts/verify-bundle.mjs
 
-      # Catches runtimes/ drifting behind src/. It compares checksums rather
-      # than bytes because Native AOT output is not bit-reproducible.
+      # Catches runtimes/ drifting behind src/, which would leave a plugin
+      # install running a stale binary. It compares a hash of the source the
+      # bundle was built from rather than rebuilding and diffing the result:
+      # Native AOT is not bit-reproducible, so a rebuild of unchanged source
+      # differs anyway, and a check that fires every time hides real drift.
       - name: Check the bundle matches source
         run: |
           node -e '
             const m = require("./runtimes/manifest.json");
             console.log("bundled:", Object.keys(m.runtimes).join(", "));
           '
-          ./scripts/build.sh osx-arm64
-          node scripts/bundle.mjs --rid osx-arm64 --from .build/bin/osx-arm64
-          if ! git diff --quiet -- runtimes/osx-arm64; then
-            echo "::warning::runtimes/ differs from a fresh build of src/. Run scripts/release.sh and commit."
-          fi
+          node scripts/source-hash.mjs --check

--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -1,4 +1,6 @@
 {
+  "version": "0.1.2",
+  "sourceHash": "70414e347c038f71715d1b53f01da6d005dc6600db71c4798c219693b23c1672",
   "runtimes": {
     "darwin-arm64": {
       "rid": "osx-arm64",
@@ -82,6 +84,5 @@
         }
       }
     }
-  },
-  "version": "0.1.2"
+  }
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -19,6 +19,7 @@ import {
 import { gzipSync } from "node:zlib";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { sourceHash } from "./source-hash.mjs";
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const runtimesDir = join(packageRoot, "runtimes");
@@ -98,6 +99,10 @@ const manifest = existsSync(manifestPath)
 manifest.version = JSON.parse(
   readFileSync(join(packageRoot, "package.json"), "utf8"),
 ).version;
+// Recorded so CI can tell whether runtimes/ still matches src/ without rebuilding.
+// Comparing the built bytes cannot answer that: Native AOT is not bit-reproducible,
+// so a rebuild of identical source differs anyway.
+manifest.sourceHash = sourceHash().hash;
 manifest.runtimes[platformKey] = { rid, executable, id: primaryHash, files };
 
 // Sorted so a rebuild of one architecture produces no incidental diff noise

--- a/scripts/source-hash.mjs
+++ b/scripts/source-hash.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Hashes the source that produces the bundled binaries, so runtimes/ can be
+// checked against src/ without rebuilding.
+//
+// The obvious check -- rebuild and diff the result against what is committed --
+// does not work here: Native AOT output is not bit-reproducible, so a fresh
+// build of unchanged source still differs. A check like that fires on every run
+// and therefore says nothing, which is worse than no check, because real drift
+// hides in the noise.
+//
+// Hashing the inputs instead is deterministic. bundle.mjs records the hash it
+// built from; CI recomputes it and compares. Same source, same hash, no rebuild
+// needed.
+//
+//   source-hash.mjs            print the hash
+//   source-hash.mjs --check    compare against the hash in runtimes/manifest.json
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Everything the compiled binaries are built from. scripts/build.sh is included
+// because it carries the publish flags, so changing them changes the output just
+// as surely as changing a source file does.
+const INPUTS = [
+	"src",
+	"native",
+	"Directory.Build.props",
+	"Directory.Packages.props",
+	"MobileCanvas.slnx",
+	"global.json",
+	"scripts/build.sh",
+];
+
+export function sourceHash() {
+	// git ls-files rather than a directory walk: it already knows what is tracked,
+	// so build output and local scratch files cannot alter the hash.
+	const listed = execFileSync("git", ["ls-files", "-z", "--", ...INPUTS], {
+		cwd: root,
+		maxBuffer: 64 * 1024 * 1024,
+	})
+		.toString("utf8")
+		.split("\0")
+		.filter(Boolean)
+		.sort();
+
+	if (listed.length === 0) {
+		throw new Error("git ls-files matched no source files -- is this a git checkout?");
+	}
+
+	const digest = createHash("sha256");
+	for (const relative of listed) {
+		// The path is hashed alongside the content so that renaming a file changes
+		// the hash even when its bytes are untouched.
+		digest.update(relative);
+		digest.update("\0");
+		digest.update(readFileSync(join(root, relative)));
+		digest.update("\0");
+	}
+
+	return { hash: digest.digest("hex"), count: listed.length };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	const { hash, count } = sourceHash();
+
+	if (process.argv[2] !== "--check") {
+		console.log(hash);
+		process.exit(0);
+	}
+
+	const manifestPath = join(root, "runtimes", "manifest.json");
+	const recorded = JSON.parse(readFileSync(manifestPath, "utf8")).sourceHash;
+
+	console.log(`  source:   ${hash} (${count} files)`);
+	console.log(`  manifest: ${recorded ?? "(none recorded)"}`);
+
+	if (!recorded) {
+		console.error(
+			"\nruntimes/manifest.json records no sourceHash, so it cannot be checked against src/."
+			+ "\nRebuild the runtimes to record one.",
+		);
+		process.exit(1);
+	}
+
+	if (recorded !== hash) {
+		console.error(
+			"\nruntimes/ was built from different source than what is here, so a plugin install"
+			+ "\nwould run a stale binary. Dispatch the 'Release runtimes' workflow to rebuild it.",
+		);
+		process.exit(1);
+	}
+
+	console.log("\nruntimes/ matches src/");
+}


### PR DESCRIPTION
CI has been warning `runtimes/ differs from a fresh build of src/` on **every single run** --
the last six checked, including the run immediately after the runtimes were rebuilt and
committed in #9. A check that always fires says nothing, and it is worse than no check, because
real drift is indistinguishable from the noise.

That matters here specifically: a plugin install is a plain file copy of `runtimes/`, so stale
runtimes are exactly the failure that leaves users installing a plugin without the tools it
advertises. This check is the only thing watching for it.

## Why it could never pass

It rebuilt and diffed the result. Its own comment said it compared checksums rather than bytes
*"because Native AOT output is not bit-reproducible"* -- but the implementation ran `git diff`
over the repacked archives, which is a byte comparison. The very non-reproducibility the comment
named is what made it fire.

## Hashing the inputs instead

`scripts/source-hash.mjs` digests the tracked contents of `src`, `native`, the build props, the
solution, `global.json` and `build.sh` -- everything the binaries are compiled from, including
the publish flags, since changing those changes the output as surely as editing a source file.
`bundle.mjs` records the hash it built from; CI recomputes it and compares.

Two details worth noting: enumeration goes through `git ls-files` rather than a directory walk,
so build output and local scratch files cannot alter the hash; and each file's path is hashed
alongside its content, so a rename is not invisible.

This also drops a full Native AOT build from every CI run, which existed only to feed a
comparison that could not work.

## Verification

Tested in both directions, which the old check could not be:

| Case | Result |
| --- | --- |
| Clean tree | passes |
| A source file touched | **fails**, naming the fix |
| That change reverted | passes again |
| A README edit | passes -- docs do not need a rebundle |
| No hash recorded at all | fails with its own message |

`bundle.mjs` was also run end to end and produced the same hash the checker computes.

The bootstrap hash is honest rather than assumed: the shipped binary reports commit `a50ad1c`,
and `git diff a50ad1c HEAD` over the hashed inputs is empty, so the recorded hash really is the
source those committed binaries were built from.
