### PR TITLE
Handle duplicate CoreSimulator runtime identifiers

### DIFF
--- a/src/MobileCanvas.iOS/SimctlCatalogParser.cs
+++ b/src/MobileCanvas.iOS/SimctlCatalogParser.cs
@@ -61,6 +61,7 @@ internal static class SimctlCatalogParser
 				};
 			})
 			.Where(runtime => runtime.Id.Length > 0)
+			.DistinctBy(runtime => runtime.Id, StringComparer.Ordinal)
 			.OrderByDescending(runtime => ParseVersion(runtime.Version))
 			.ToArray();
 	}

--- a/tests/MobileCanvas.Tests/SimctlParserTests.cs
+++ b/tests/MobileCanvas.Tests/SimctlParserTests.cs
@@ -52,6 +52,61 @@ public sealed class SimctlParserTests
 	}
 
 	[Fact]
+	public void Parse_DeduplicatesRuntimeIdentifiersAndResolvesDeviceMetadata()
+	{
+		const string json = """
+		{
+		  "runtimes": [{
+		    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+		    "buildversion": "24A5279h",
+		    "name": "iOS 27.0",
+		    "version": "27.0",
+		    "isAvailable": true,
+		    "supportedArchitectures": ["arm64"],
+		    "supportedDeviceTypes": [{
+		      "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro"
+		    }]
+		  }, {
+		    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+		    "buildversion": "24A5298h",
+		    "name": "iOS 27.0",
+		    "version": "27.0",
+		    "isAvailable": true,
+		    "supportedArchitectures": ["arm64"],
+		    "supportedDeviceTypes": [{
+		      "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro"
+		    }]
+		  }],
+		  "devicetypes": [{
+		    "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro",
+		    "name": "iPhone 17 Pro",
+		    "productFamily": "iPhone",
+		    "modelIdentifier": "iPhone18,1"
+		  }],
+		  "devices": {
+		    "com.apple.CoreSimulator.SimRuntime.iOS-27-0": [{
+		      "name": "Beta Test iPhone",
+		      "udid": "EFGH-5678",
+		      "state": "Shutdown",
+		      "isAvailable": true,
+		      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro"
+		    }]
+		  }
+		}
+		""";
+
+		var catalog = SimctlCatalogParser.Parse(json);
+		var runtime = Assert.Single(catalog.Runtimes);
+		var device = Assert.Single(catalog.Devices);
+
+		Assert.Equal("com.apple.CoreSimulator.SimRuntime.iOS-27-0", runtime.Id);
+		Assert.Equal(runtime.Id, device.RuntimeId);
+		Assert.Equal("iOS 27.0", device.RuntimeName);
+		Assert.Equal("27.0", device.OsVersion);
+		Assert.Equal("iPhone 17 Pro", device.DeviceTypeName);
+	}
+
+	[Fact]
 	public void DisplayParser_MapsLogicalGeometryAndOrientation()
 	{
 		const string output = """


### PR DESCRIPTION
## Summary
- Deduplicate CoreSimulator runtimes by identifier before building the runtime lookup.
- Prevent duplicate Xcode beta runtime builds from breaking device catalog parsing.
- Add regression coverage that verifies one catalog runtime and resolved device metadata.

## Testing
- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --filter FullyQualifiedName~MobileCanvas.Tests.SimctlParserTests --no-restore`
- `dotnet test MobileCanvas.slnx -c Release --no-restore` (230 passed)