### PR TITLE
Fix mobile canvas recovery after host restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ GitHub Copilot app        VS Code extension          CLI / other agent
 ```
 
 The host is started on demand, binds only to `127.0.0.1`, and authenticates
-canvas panels with a single-use bootstrap secret exchanged for a session cookie.
+canvas panels with a scoped reload grant exchanged for a rotating session cookie.
+The grant remains in the URL fragment so a host-restored renderer can reconnect
+without exposing the credential in an HTTP request.
 It exits after an idle grace period and **never** shuts down a device
 implicitly, so detaching a panel is always safe.
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -79,7 +79,7 @@ and the bundled native executable are local-machine resources.
 native runtime or reach local simulators.
 
 All Mobile Canvas traffic remains on `127.0.0.1`. The extension host exchanges
-the host's one-time bootstrap secret for a scoped cookie, then relays typed HTTP
+the host's panel-scoped reload grant for a rotating cookie, then relays typed HTTP
 requests and binary WebSocket frames. Webview JavaScript receives neither the
 bootstrap secret nor the authenticated cookie.
 

--- a/scripts/verify-vsix.mjs
+++ b/scripts/verify-vsix.mjs
@@ -47,6 +47,7 @@ function verifyExtracted(directory) {
     "extension/media/vscode-theme.js",
     "extension/media/vscode-transport.js",
     "extension/dist/web/index.html",
+    "extension/dist/web/canvas-state.js",
     "extension/dist/web/create-device-options.js",
     "extension/dist/web/device-canvas.css",
     "extension/dist/web/device-canvas.js",

--- a/src/MobileCanvas.Tool/CanvasBootstrapStore.cs
+++ b/src/MobileCanvas.Tool/CanvasBootstrapStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using MobileCanvas.Contracts;
 
@@ -6,52 +5,117 @@ namespace MobileCanvas.Tool;
 
 internal sealed class CanvasBootstrapStore
 {
-	private readonly ConcurrentDictionary<string, BootstrapGrant> _grants = new();
-	private readonly ConcurrentDictionary<string, CanvasContextKey> _sessions = new();
+	internal static readonly TimeSpan CredentialLifetime = TimeSpan.FromDays(30);
+
+	private readonly object _gate = new();
+	private readonly Dictionary<string, BootstrapGrant> _grants = [];
+	private readonly Dictionary<string, BrowserSession> _sessions = [];
 
 	public string Create(CanvasContextKey key)
 	{
-		CleanupExpired();
-		var secret = CreateSecret();
-		_grants[secret] = new BootstrapGrant(key, DateTimeOffset.UtcNow.AddMinutes(1));
-		return secret;
+		lock (_gate)
+		{
+			var now = DateTimeOffset.UtcNow;
+			CleanupExpired(now);
+			RemoveGrants(key);
+			RemoveSessions(key);
+
+			var secret = CreateSecret();
+			_grants[secret] = new BootstrapGrant(key, now.Add(CredentialLifetime));
+			return secret;
+		}
 	}
 
 	public string Exchange(CanvasBootstrapRequest request)
 	{
-		if (!_grants.TryRemove(request.Secret, out var grant) ||
-			grant.ExpiresAt < DateTimeOffset.UtcNow ||
-			!grant.Key.SessionId.Equals(request.SessionId, StringComparison.Ordinal) ||
-			!grant.Key.InstanceId.Equals(request.InstanceId, StringComparison.Ordinal))
+		lock (_gate)
 		{
-			throw new UnauthorizedAccessException("The canvas bootstrap secret is invalid or expired.");
-		}
+			var now = DateTimeOffset.UtcNow;
+			CleanupExpired(now);
+			if (!_grants.TryGetValue(request.Secret, out var grant) ||
+				!grant.Key.SessionId.Equals(request.SessionId, StringComparison.Ordinal) ||
+				!grant.Key.InstanceId.Equals(request.InstanceId, StringComparison.Ordinal))
+			{
+				throw new UnauthorizedAccessException("The canvas bootstrap secret is invalid or expired.");
+			}
 
-		var session = CreateSecret();
-		_sessions[session] = grant.Key;
-		return session;
+			// Canvas renderers reload without invoking the provider's open callback. Keep the scoped
+			// grant reusable, but rotate the browser session so only the newest renderer stays active.
+			RemoveSessions(grant.Key);
+			_grants[request.Secret] = grant with { ExpiresAt = now.Add(CredentialLifetime) };
+			var session = CreateSecret();
+			_sessions[session] = new BrowserSession(grant.Key, now.Add(CredentialLifetime));
+			return session;
+		}
 	}
 
-	public bool TryGetSession(string session, out CanvasContextKey key) =>
-		_sessions.TryGetValue(session, out key!);
+	public bool TryGetSession(string session, out CanvasContextKey key)
+	{
+		lock (_gate)
+		{
+			if (_sessions.TryGetValue(session, out var browserSession) &&
+				browserSession.ExpiresAt >= DateTimeOffset.UtcNow)
+			{
+				key = browserSession.Key;
+				return true;
+			}
+
+			_sessions.Remove(session);
+			key = null!;
+			return false;
+		}
+	}
+
+	public void Close(CanvasContextKey key)
+	{
+		lock (_gate)
+			RemoveSessions(key);
+	}
 
 	public void Detach(CanvasContextKey key)
 	{
-		foreach (var session in _sessions.Where(pair => pair.Value == key).Select(pair => pair.Key))
-			_sessions.TryRemove(session, out _);
-		foreach (var grant in _grants.Where(pair => pair.Value.Key == key).Select(pair => pair.Key))
-			_grants.TryRemove(grant, out _);
+		lock (_gate)
+		{
+			RemoveSessions(key);
+			RemoveGrants(key);
+		}
 	}
 
-	private void CleanupExpired()
+	private void CleanupExpired(DateTimeOffset now)
 	{
-		var now = DateTimeOffset.UtcNow;
-		foreach (var grant in _grants.Where(pair => pair.Value.ExpiresAt < now).Select(pair => pair.Key))
-			_grants.TryRemove(grant, out _);
+		foreach (var grant in _grants
+			.Where(pair => pair.Value.ExpiresAt < now)
+			.Select(pair => pair.Key)
+			.ToArray())
+			_grants.Remove(grant);
+		foreach (var session in _sessions
+			.Where(pair => pair.Value.ExpiresAt < now)
+			.Select(pair => pair.Key)
+			.ToArray())
+			_sessions.Remove(session);
+	}
+
+	private void RemoveGrants(CanvasContextKey key)
+	{
+		foreach (var grant in _grants
+			.Where(pair => pair.Value.Key == key)
+			.Select(pair => pair.Key)
+			.ToArray())
+			_grants.Remove(grant);
+	}
+
+	private void RemoveSessions(CanvasContextKey key)
+	{
+		foreach (var session in _sessions
+			.Where(pair => pair.Value.Key == key)
+			.Select(pair => pair.Key)
+			.ToArray())
+			_sessions.Remove(session);
 	}
 
 	private static string CreateSecret() =>
 		Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
 
 	private sealed record BootstrapGrant(CanvasContextKey Key, DateTimeOffset ExpiresAt);
+	private sealed record BrowserSession(CanvasContextKey Key, DateTimeOffset ExpiresAt);
 }

--- a/src/MobileCanvas.Tool/DeviceApi.cs
+++ b/src/MobileCanvas.Tool/DeviceApi.cs
@@ -131,6 +131,7 @@ internal static class DeviceApi
 
 	internal static bool IsPublicPath(PathString path) =>
 		path == "/" ||
+		path == "/canvas-state.js" ||
 		path == "/create-device-options.js" ||
 		path == "/device-canvas.js" ||
 		path == "/device-canvas.css" ||
@@ -139,6 +140,9 @@ internal static class DeviceApi
 	private static void MapAssets(WebApplication app)
 	{
 		app.MapGet("/", () => EmbeddedAsset("index.html", "text/html; charset=utf-8"));
+		app.MapGet(
+			"/canvas-state.js",
+			() => EmbeddedAsset("canvas-state.js", "text/javascript; charset=utf-8"));
 		app.MapGet(
 			"/create-device-options.js",
 			() => EmbeddedAsset("create-device-options.js", "text/javascript; charset=utf-8"));
@@ -167,6 +171,7 @@ internal static class DeviceApi
 						SameSite = SameSiteMode.Strict,
 						Secure = false,
 						Path = "/",
+						MaxAge = CanvasBootstrapStore.CredentialLifetime,
 					});
 				return Results.NoContent();
 			});
@@ -214,8 +219,9 @@ internal static class DeviceApi
 				RequireControl(context);
 				ValidateCanvasContext(request.SessionId, request.InstanceId);
 				var key = new CanvasContextKey(request.SessionId, request.InstanceId);
-				store.Detach(key);
-				devices.Detach(key);
+				// Host applications restore an open renderer without invoking canvas.open again.
+				// Keep its grant and selection until explicit detach, but rotate the browser session.
+				store.Close(key);
 				return Results.NoContent();
 			});
 

--- a/src/MobileCanvas.Tool/MobileCanvas.Tool.csproj
+++ b/src/MobileCanvas.Tool/MobileCanvas.Tool.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\..\web\index.html" LogicalName="MobileCanvas.Web.index.html" />
+    <EmbeddedResource Include="..\..\web\canvas-state.js" LogicalName="MobileCanvas.Web.canvas-state.js" />
     <EmbeddedResource Include="..\..\web\create-device-options.js" LogicalName="MobileCanvas.Web.create-device-options.js" />
     <EmbeddedResource Include="..\..\web\device-canvas.js" LogicalName="MobileCanvas.Web.device-canvas.js" />
     <EmbeddedResource Include="..\..\web\device-canvas.css" LogicalName="MobileCanvas.Web.device-canvas.css" />

--- a/tests/MobileCanvas.Tests/CanvasBootstrapStoreTests.cs
+++ b/tests/MobileCanvas.Tests/CanvasBootstrapStoreTests.cs
@@ -6,7 +6,7 @@ namespace MobileCanvas.Tests;
 public sealed class CanvasBootstrapStoreTests
 {
 	[Fact]
-	public void Exchange_IsOneTimeAndBoundToCanvasContext()
+	public void Exchange_RotatesSessionAndKeepsGrantForRendererReload()
 	{
 		var store = new CanvasBootstrapStore();
 		var key = new CanvasContextKey("session", "instance");
@@ -18,27 +18,80 @@ public sealed class CanvasBootstrapStoreTests
 			InstanceId = key.InstanceId,
 		};
 
-		var session = store.Exchange(request);
+		var firstSession = store.Exchange(request);
+		var secondSession = store.Exchange(request);
 
-		Assert.True(store.TryGetSession(session, out var actual));
+		Assert.NotEqual(firstSession, secondSession);
+		Assert.False(store.TryGetSession(firstSession, out _));
+		Assert.True(store.TryGetSession(secondSession, out var actual));
 		Assert.Equal(key, actual);
-		Assert.Throws<UnauthorizedAccessException>(() => store.Exchange(request));
 	}
 
 	[Fact]
-	public void Detach_InvalidatesBrowserSession()
+	public void Exchange_IsBoundToCanvasContext()
+	{
+		var store = new CanvasBootstrapStore();
+		var secret = store.Create(new CanvasContextKey("session", "instance"));
+
+		Assert.Throws<UnauthorizedAccessException>(() => store.Exchange(new CanvasBootstrapRequest
+		{
+			Secret = secret,
+			SessionId = "other-session",
+			InstanceId = "instance",
+		}));
+	}
+
+	[Fact]
+	public void CreatingReplacementGrant_InvalidatesPriorCredentials()
 	{
 		var store = new CanvasBootstrapStore();
 		var key = new CanvasContextKey("session", "instance");
-		var session = store.Exchange(new CanvasBootstrapRequest
-		{
-			Secret = store.Create(key),
-			SessionId = key.SessionId,
-			InstanceId = key.InstanceId,
-		});
+		var firstSecret = store.Create(key);
+		var firstSession = store.Exchange(Request(firstSecret, key));
+
+		var secondSecret = store.Create(key);
+
+		Assert.False(store.TryGetSession(firstSession, out _));
+		Assert.Throws<UnauthorizedAccessException>(() => store.Exchange(Request(firstSecret, key)));
+		Assert.True(store.TryGetSession(store.Exchange(Request(secondSecret, key)), out var actual));
+		Assert.Equal(key, actual);
+	}
+
+	[Fact]
+	public void Close_InvalidatesSessionButKeepsRendererReloadGrant()
+	{
+		var store = new CanvasBootstrapStore();
+		var key = new CanvasContextKey("session", "instance");
+		var secret = store.Create(key);
+		var request = Request(secret, key);
+		var firstSession = store.Exchange(request);
+
+		store.Close(key);
+
+		Assert.False(store.TryGetSession(firstSession, out _));
+		Assert.True(store.TryGetSession(store.Exchange(request), out var actual));
+		Assert.Equal(key, actual);
+	}
+
+	[Fact]
+	public void Detach_InvalidatesGrantAndBrowserSession()
+	{
+		var store = new CanvasBootstrapStore();
+		var key = new CanvasContextKey("session", "instance");
+		var secret = store.Create(key);
+		var request = Request(secret, key);
+		var session = store.Exchange(request);
 
 		store.Detach(key);
 
 		Assert.False(store.TryGetSession(session, out _));
+		Assert.Throws<UnauthorizedAccessException>(() => store.Exchange(request));
 	}
+
+	private static CanvasBootstrapRequest Request(string secret, CanvasContextKey key) => new()
+	{
+		Secret = secret,
+		SessionId = key.SessionId,
+		InstanceId = key.InstanceId,
+	};
 }

--- a/tests/MobileCanvas.Tests/DeviceApiTests.cs
+++ b/tests/MobileCanvas.Tests/DeviceApiTests.cs
@@ -7,6 +7,7 @@ public sealed class DeviceApiTests
 {
 	[Theory]
 	[InlineData("/")]
+	[InlineData("/canvas-state.js")]
 	[InlineData("/create-device-options.js")]
 	[InlineData("/device-canvas.js")]
 	[InlineData("/device-canvas.css")]
@@ -17,13 +18,15 @@ public sealed class DeviceApiTests
 	}
 
 	[Fact]
-	public void CreateDeviceOptions_IsEmbedded()
+	public void WebModules_AreEmbedded()
 	{
-		using var stream = typeof(DeviceApi).Assembly.GetManifestResourceStream(
-			"MobileCanvas.Web.create-device-options.js");
-
-		Assert.NotNull(stream);
-		Assert.True(stream.Length > 0);
+		foreach (var name in new[] { "canvas-state.js", "create-device-options.js" })
+		{
+			using var stream = typeof(DeviceApi).Assembly.GetManifestResourceStream(
+				$"MobileCanvas.Web.{name}");
+			Assert.NotNull(stream);
+			Assert.True(stream.Length > 0);
+		}
 	}
 
 	[Fact]

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,7 +131,7 @@
   },
   "scripts": {
     "compile": "tsc -p .",
-    "check:web": "node --check ../web/device-canvas.js && node --check media/vscode-theme.js && node --check media/vscode-transport.js",
+    "check:web": "node --check ../web/canvas-state.js && node --check ../web/device-canvas.js && node --check media/vscode-theme.js && node --check media/vscode-transport.js",
     "check:scripts": "node --check ../lib/runtime.mjs && node --check ../lib/runtime-assets.mjs && node --check ../lib/mcp-vscode-proxy.mjs && node --check ../scripts/mcp-vscode.mjs && node --check ../scripts/prepare-vscode.mjs && node --check ../scripts/prepare-plugin.mjs && node --check ../scripts/package-runtime-assets.mjs && node --check ../scripts/package-vscode-thin.mjs && node --check ../scripts/package-vscode-targets.mjs && node --check ../scripts/verify-vsix.mjs",
     "prepare-assets": "node ../scripts/prepare-vscode.mjs",
     "build": "npm run compile && npm run check:web && npm run check:scripts && npm run prepare-assets",

--- a/vscode/src/hostBridge.ts
+++ b/vscode/src/hostBridge.ts
@@ -21,6 +21,11 @@ interface CanvasOpenResult {
   title?: string;
 }
 
+interface HostConnection {
+  baseUrl: URL;
+  cookie: string;
+}
+
 interface MessageSink {
   postMessage(message: ExtensionMessage): Thenable<boolean>;
 }
@@ -37,9 +42,8 @@ export interface SelectedDeviceContext {
 
 export class HostBridge implements vscode.Disposable {
   private readonly sockets = new Map<string, WebSocket>();
-  private baseUrl: URL | undefined;
-  private cookie: string | undefined;
-  private connectPromise: Promise<void> | undefined;
+  private connection: HostConnection | undefined;
+  private connectPromise: Promise<HostConnection> | undefined;
   private disposed = false;
   private signalOffset = 0;
   private selectionToRestore: string | undefined;
@@ -111,9 +115,7 @@ export class HostBridge implements vscode.Disposable {
   async restart(): Promise<void> {
     this.selectionToRestore = await this.readSelectedDeviceId();
     await this.closeCanvas();
-    this.connectPromise = undefined;
-    this.baseUrl = undefined;
-    this.cookie = undefined;
+    this.invalidateConnection();
   }
 
   async getSelectedDeviceContext(): Promise<SelectedDeviceContext> {
@@ -180,15 +182,27 @@ export class HostBridge implements vscode.Disposable {
     });
   }
 
-  private async connect(): Promise<void> {
+  private async connect(): Promise<HostConnection> {
     if (this.disposed) {
       throw new Error("The Mobile Canvas view is closed.");
     }
-    this.connectPromise ??= this.openCanvas();
-    await this.connectPromise;
+    const pending = this.connectPromise ??= this.openCanvas();
+    try {
+      const connection = await pending;
+      if (this.connectPromise === pending) {
+        this.connection = connection;
+      }
+      return connection;
+    } catch (error) {
+      if (this.connectPromise === pending) {
+        this.connectPromise = undefined;
+        this.connection = undefined;
+      }
+      throw error;
+    }
   }
 
-  private async openCanvas(): Promise<void> {
+  private async openCanvas(): Promise<HostConnection> {
     const { stdout } = await execFileAsync(
       this.command,
       [
@@ -243,67 +257,94 @@ export class HostBridge implements vscode.Disposable {
       throw new Error("The Mobile Canvas host did not establish a panel session.");
     }
 
-    this.baseUrl = baseUrl;
-    this.cookie = cookie;
-    await this.restoreSelection();
+    const connection = { baseUrl, cookie };
+    await this.restoreSelection(connection);
+    return connection;
   }
 
   private async forwardApi(
     message: Extract<WebviewMessage, { type: "api" }>,
   ): Promise<void> {
-    await this.connect();
     const method = (message.method ?? "GET").toUpperCase();
     if (!ALLOWED_METHODS.has(method)) {
       throw new Error(`Unsupported Mobile Canvas HTTP method: ${method}`);
     }
-    const url = this.apiUrl(message.path);
-    const headers: Record<string, string> = { Cookie: this.cookie! };
-    if (message.body !== undefined) {
-      headers["Content-Type"] = "application/json";
-    }
 
-    try {
-      const response = await fetch(url, {
-        method,
-        headers,
-        body: message.body,
-        signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
-      });
-      const body = response.status === 204 || response.status === 205 || response.status === 304
-        ? null
-        : await response.arrayBuffer();
-      const responseHeaders = Object.fromEntries(response.headers.entries());
-      delete responseHeaders["set-cookie"];
-      delete responseHeaders["set-cookie2"];
-      await this.post({
-        type: "api-result",
-        id: message.id,
-        status: response.status,
-        statusText: response.statusText,
-        headers: responseHeaders,
-        body,
-      });
-    } catch (error) {
-      await this.post({
-        type: "api-error",
-        id: message.id,
-        message: errorMessage(error),
-      });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const connection = await this.connect();
+      const url = this.apiUrl(message.path, connection);
+      const headers: Record<string, string> = { Cookie: connection.cookie };
+      if (message.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+      }
+
+      try {
+        const response = await fetch(url, {
+          method,
+          headers,
+          body: message.body,
+          signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
+        });
+        if (response.status === 401 && attempt === 0) {
+          this.invalidateConnection(connection);
+          continue;
+        }
+        const body = response.status === 204 || response.status === 205 || response.status === 304
+          ? null
+          : await response.arrayBuffer();
+        const responseHeaders = Object.fromEntries(response.headers.entries());
+        delete responseHeaders["set-cookie"];
+        delete responseHeaders["set-cookie2"];
+        await this.post({
+          type: "api-result",
+          id: message.id,
+          status: response.status,
+          statusText: response.statusText,
+          headers: responseHeaders,
+          body,
+        });
+        return;
+      } catch (error) {
+        this.invalidateConnection(connection);
+        if (method === "GET" && attempt === 0 && isConnectionFailure(error)) {
+          continue;
+        }
+        await this.post({
+          type: "api-error",
+          id: message.id,
+          message: errorMessage(error),
+        });
+        return;
+      }
     }
   }
 
   private async get(path: string): Promise<Response> {
-    await this.connect();
-    const response = await fetch(this.apiUrl(path), {
-      headers: { Cookie: this.cookie! },
-      signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Mobile Canvas request failed: ${response.status} ${response.statusText}`,
-      );
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const connection = await this.connect();
+      try {
+        const response = await fetch(this.apiUrl(path, connection), {
+          headers: { Cookie: connection.cookie },
+          signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
+        });
+        if (response.status === 401 && attempt === 0) {
+          this.invalidateConnection(connection);
+          continue;
+        }
+        if (!response.ok) {
+          throw new Error(
+            `Mobile Canvas request failed: ${response.status} ${response.statusText}`,
+          );
+        }
+        return response;
+      } catch (error) {
+        if (!isConnectionFailure(error) || attempt > 0) {
+          throw error;
+        }
+        this.invalidateConnection(connection);
+      }
     }
-    return response;
+    throw new Error("Mobile Canvas could not reconnect to its local host.");
   }
 
   private async getJson(path: string): Promise<unknown> {
@@ -322,18 +363,20 @@ export class HostBridge implements vscode.Disposable {
     channel: SocketChannel,
     query?: string,
   ): Promise<void> {
-    await this.connect();
+    const connection = await this.connect();
     if (channel !== "video" && channel !== "events") {
       throw new Error(`Unsupported Mobile Canvas socket channel: ${String(channel)}`);
     }
     this.closeSocket(id);
-    const url = this.apiUrl(`/ws/${channel}`);
+    const url = this.apiUrl(`/ws/${channel}`, connection);
     url.search = query ?? "";
     url.protocol = "ws:";
-    const socket = new WebSocket(url, { headers: { Cookie: this.cookie! } });
+    const socket = new WebSocket(url, { headers: { Cookie: connection.cookie } });
     this.sockets.set(id, socket);
+    let opened = false;
 
     socket.on("open", () => {
+      opened = true;
       void this.post({ type: "socket-opened", id });
     });
     socket.on("message", (data, isBinary) => {
@@ -348,6 +391,9 @@ export class HostBridge implements vscode.Disposable {
       void this.post({ type: "socket-message", id, data: payload });
     });
     socket.on("error", (error) => {
+      if (!opened) {
+        this.invalidateConnection(connection);
+      }
       void this.post({ type: "socket-error", id, message: error.message });
     });
     socket.on("close", (code, reason) => {
@@ -397,18 +443,17 @@ export class HostBridge implements vscode.Disposable {
     await this.post({ type: "operation-result", id });
   }
 
-  private apiUrl(path: string): URL {
+  private apiUrl(path: string, connection: HostConnection): URL {
     if (
-      !this.baseUrl
-      || (!path.startsWith("/api/v1/") && !path.startsWith("/ws/"))
+      !path.startsWith("/api/v1/") && !path.startsWith("/ws/")
     ) {
       throw new Error(`Invalid Mobile Canvas host path: ${path}`);
     }
-    const url = new URL(path, this.baseUrl);
+    const url = new URL(path, connection.baseUrl);
     const validPath = path.startsWith("/api/v1/")
       ? url.pathname.startsWith("/api/v1/")
       : url.pathname === "/ws/video" || url.pathname === "/ws/events";
-    if (url.origin !== this.baseUrl.origin || !validPath) {
+    if (url.origin !== connection.baseUrl.origin || !validPath) {
       throw new Error("Mobile Canvas requests must remain on the local host.");
     }
     return url;
@@ -447,9 +492,9 @@ export class HostBridge implements vscode.Disposable {
   private async readSelectedDeviceId(): Promise<string | undefined> {
     if (!this.connectPromise) return undefined;
     try {
-      await this.connectPromise;
-      const response = await fetch(this.apiUrl("/api/v1/selection"), {
-        headers: { Cookie: this.cookie! },
+      const connection = await this.connectPromise;
+      const response = await fetch(this.apiUrl("/api/v1/selection", connection), {
+        headers: { Cookie: connection.cookie },
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
       if (!response.ok) {
@@ -472,15 +517,15 @@ export class HostBridge implements vscode.Disposable {
     }
   }
 
-  private async restoreSelection(): Promise<void> {
+  private async restoreSelection(connection: HostConnection): Promise<void> {
     const deviceId = this.selectionToRestore;
     this.selectionToRestore = undefined;
     if (!deviceId) return;
     try {
-      const response = await fetch(this.apiUrl("/api/v1/selection"), {
+      const response = await fetch(this.apiUrl("/api/v1/selection", connection), {
         method: "POST",
         headers: {
-          Cookie: this.cookie!,
+          Cookie: connection.cookie,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ deviceId }),
@@ -496,6 +541,15 @@ export class HostBridge implements vscode.Disposable {
         `Mobile Canvas could not restore ${deviceId}: ${errorMessage(error)}`,
       );
     }
+  }
+
+  private invalidateConnection(connection?: HostConnection): void {
+    if (connection && this.connection !== connection) {
+      return;
+    }
+    this.closeSockets();
+    this.connection = undefined;
+    this.connectPromise = undefined;
   }
 
   private post(message: ExtensionMessage): Thenable<boolean> {
@@ -568,6 +622,10 @@ function errorMessage(error: unknown): string {
     }
   }
   return error instanceof Error ? error.message : String(error);
+}
+
+function isConnectionFailure(error: unknown): boolean {
+  return error instanceof TypeError;
 }
 
 function isLoopback(hostname: string): boolean {

--- a/vscode/src/test/suite/index.ts
+++ b/vscode/src/test/suite/index.ts
@@ -78,6 +78,7 @@ async function verifyHostBridge(): Promise<void> {
   let apiCookie = "";
   let socketCookie = "";
   let selectionRestores = 0;
+  let rejectCatalogOnce = false;
   const server = createServer((request, response) => {
     if (request.url === "/api/v1/auth/bootstrap") {
       let body = "";
@@ -96,6 +97,12 @@ async function verifyHostBridge(): Promise<void> {
       return;
     }
     if (request.url === "/api/v1/catalog") {
+      if (rejectCatalogOnce) {
+        rejectCatalogOnce = false;
+        response.statusCode = 401;
+        response.end();
+        return;
+      }
       apiCookie = request.headers.cookie ?? "";
       response.setHeader("Content-Type", "application/json");
       response.setHeader("Set-Cookie", "mobile_device_session=must-not-leak");
@@ -273,6 +280,16 @@ if (args[0] === "canvas" && args[1] === "open") {
       );
     }
 
+    const bootstrapsBeforeReconnect = bootstrapBodies.length;
+    rejectCatalogOnce = true;
+    await bridge.handleMessage({
+      type: "api",
+      id: "catalog-after-session-expired",
+      path: "/api/v1/catalog",
+    });
+    assert.equal(bootstrapBodies.length, bootstrapsBeforeReconnect + 1);
+    assert.equal(messages.shift()?.type, "api-result");
+
     await bridge.handleMessage({
       type: "api",
       id: "escape",
@@ -318,13 +335,16 @@ if (args[0] === "canvas" && args[1] === "open") {
     assert.ok(messages.some(
       (message) => message.type === "visibility" && !message.visible,
     ));
+    const bootstrapsBeforeRestart = bootstrapBodies.length;
     await bridge.restart();
     await bridge.handleMessage({ type: "ready" });
+    assert.equal(bootstrapBodies.length, bootstrapsBeforeRestart + 1);
     assert.equal(selectionRestores, 1);
 
+    const bootstrapsBeforeView = bootstrapBodies.length;
     await vscode.commands.executeCommand("mobileCanvas.open");
-    await waitFor(() => bootstrapBodies.length >= 3);
-    const viewBootstrap = JSON.parse(bootstrapBodies[2]);
+    await waitFor(() => bootstrapBodies.length > bootstrapsBeforeView);
+    const viewBootstrap = JSON.parse(bootstrapBodies.at(-1)!);
     assert.equal(viewBootstrap.secret, "test-secret");
     assert.match(viewBootstrap.sessionId, /^[0-9a-f-]{36}$/);
     assert.notEqual(viewBootstrap.sessionId, vscode.env.sessionId);

--- a/vscode/test/canvas-state.test.mjs
+++ b/vscode/test/canvas-state.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  clearStoredDeviceId,
+  readStoredDeviceId,
+  storeDeviceId,
+} from "../../web/canvas-state.js";
+
+test("persists and clears the selected device used after a host restart", () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+
+  assert.equal(readStoredDeviceId(storage, "panel-a"), null);
+  storeDeviceId(storage, "panel-a", "ios:phone");
+  storeDeviceId(storage, "panel-b", "android:pixel");
+  assert.equal(readStoredDeviceId(storage, "panel-a"), "ios:phone");
+  assert.equal(readStoredDeviceId(storage, "panel-b"), "android:pixel");
+  clearStoredDeviceId(storage, "panel-a");
+  assert.equal(readStoredDeviceId(storage, "panel-a"), null);
+  assert.equal(readStoredDeviceId(storage, "panel-b"), "android:pixel");
+});
+
+test("rejects an empty selected device ID", () => {
+  const storage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+
+  assert.throws(() => storeDeviceId(storage, "panel", ""), /selected device ID/);
+  assert.throws(() => readStoredDeviceId(storage, ""), /canvas instance ID/);
+});

--- a/vscode/test/prepared-assets.test.mjs
+++ b/vscode/test/prepared-assets.test.mjs
@@ -9,6 +9,7 @@ const extensionRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 test("prepared extension assets contain the shared runtime and UI", () => {
   for (const relative of [
     "dist/web/index.html",
+    "dist/web/canvas-state.js",
     "dist/web/create-device-options.js",
     "dist/web/device-canvas.js",
     "dist/lib/runtime.mjs",

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -1,0 +1,24 @@
+const SELECTED_DEVICE_PREFIX = "mobile-canvas-selected-device:";
+
+export function readStoredDeviceId(storage, instanceId) {
+  const value = storage.getItem(storageKey(instanceId));
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function storeDeviceId(storage, instanceId, deviceId) {
+  if (typeof deviceId !== "string" || deviceId.length === 0) {
+    throw new TypeError("A selected device ID is required.");
+  }
+  storage.setItem(storageKey(instanceId), deviceId);
+}
+
+export function clearStoredDeviceId(storage, instanceId) {
+  storage.removeItem(storageKey(instanceId));
+}
+
+function storageKey(instanceId) {
+  if (typeof instanceId !== "string" || instanceId.length === 0) {
+    throw new TypeError("A canvas instance ID is required.");
+  }
+  return `${SELECTED_DEVICE_PREFIX}${instanceId}`;
+}

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -1,4 +1,9 @@
 import { creatablePlatforms, createOptions } from "./create-device-options.js";
+import {
+  clearStoredDeviceId,
+  readStoredDeviceId,
+  storeDeviceId,
+} from "./canvas-state.js";
 
 const elements = {
   list: document.querySelector("#device-list"),
@@ -62,6 +67,7 @@ const elements = {
 };
 
 const transport = window.mobileCanvasTransport || null;
+let bootstrapExchange = null;
 
 const state = {
   catalog: null,
@@ -95,6 +101,19 @@ const state = {
 };
 
 async function api(path, options = {}) {
+  let response = await sendApiRequest(path, options);
+  if (
+    response.status === 401
+    && !transport
+    && path !== "/api/v1/auth/bootstrap"
+    && await exchangeBootstrapGrant()
+  ) {
+    response = await sendApiRequest(path, options);
+  }
+  return requireSuccessfulResponse(response);
+}
+
+async function sendApiRequest(path, options = {}) {
   const request = {
     credentials: "same-origin",
     ...options,
@@ -103,9 +122,12 @@ async function api(path, options = {}) {
       ...(options.headers || {}),
     },
   };
-  const response = transport
+  return transport
     ? await transport.api(path, request)
     : await fetch(path, request);
+}
+
+async function requireSuccessfulResponse(response) {
   if (!response.ok) {
     const payload = await response.json().catch(() => ({
       message: `${response.status} ${response.statusText}`,
@@ -127,19 +149,32 @@ async function bootstrap() {
     return;
   }
 
+  await exchangeBootstrapGrant();
+}
+
+function exchangeBootstrapGrant() {
+  bootstrapExchange ??= performBootstrapExchange().finally(() => {
+    bootstrapExchange = null;
+  });
+  return bootstrapExchange;
+}
+
+async function performBootstrapExchange() {
   const fragment = new URLSearchParams(location.hash.slice(1));
   const secret = fragment.get("bootstrap");
-  if (!secret) return;
-
+  if (!secret) return false;
   const sessionId = fragment.get("sessionId");
   const instanceId = fragment.get("instanceId");
   sessionStorage.setItem("mobile-canvas-session", sessionId || "");
   sessionStorage.setItem("mobile-canvas-instance", instanceId || "");
-  await api("/api/v1/auth/bootstrap", {
+  const response = await sendApiRequest("/api/v1/auth/bootstrap", {
     method: "POST",
     body: JSON.stringify({ secret, sessionId, instanceId }),
   });
-  history.replaceState(null, "", location.pathname);
+  await requireSuccessfulResponse(response);
+  // Copilot reloads a persisted renderer without calling the provider's open callback. The scoped
+  // fragment is therefore retained so this page can exchange it for a fresh browser session.
+  return true;
 }
 
 async function refresh() {
@@ -163,6 +198,14 @@ async function refresh() {
       await selectDevice(selection.device, false);
       return;
     }
+
+    const storedDeviceId = readStoredDeviceId(localStorage, canvasInstanceId());
+    const storedDevice = state.catalog.devices.find((device) => device.id === storedDeviceId);
+    if (storedDevice) {
+      await selectDevice(storedDevice, true);
+      return;
+    }
+    if (storedDeviceId) clearStoredDeviceId(localStorage, canvasInstanceId());
 
     const booted = state.catalog.devices.find((device) => device.state === "booted");
     if (booted) {
@@ -340,6 +383,7 @@ async function selectDevice(device, persist) {
   if (selectionVersion !== state.selectionVersion) return;
 
   state.selected = device;
+  storeDeviceId(localStorage, canvasInstanceId(), device.id);
   // A cursor left over from the previous device would point at coordinates that no longer mean
   // anything, so drop the overlay whenever the selection changes.
   endAutomation();
@@ -1991,6 +2035,7 @@ async function detach() {
   clearTimeout(automation.retryTimer);
   socket?.close();
   await api("/api/v1/canvas/detach", { method: "POST" });
+  clearStoredDeviceId(localStorage, canvasInstanceId());
   state.detached = true;
   transport?.setViewTitle?.("Device", "Detached");
   elements.view.classList.add("hidden");
@@ -2123,6 +2168,14 @@ function createSocket(channel, query) {
   return new WebSocket(
     `${protocol}//${location.host}/ws/${channel}${query ? `?${query}` : ""}`,
   );
+}
+
+function canvasInstanceId() {
+  const instanceId = sessionStorage.getItem("mobile-canvas-instance");
+  if (!instanceId) {
+    throw new Error("Mobile Canvas has no active panel identity.");
+  }
+  return instanceId;
 }
 
 function setPanelVisible(visible) {


### PR DESCRIPTION
Restored mobile canvases could become unusable after restarting GitHub Copilot or VS Code because renderer reloads do not rerun the provider's open callback, while bootstrap credentials were single-use and connection and selection state lived only in memory.

## What changed

- Keep panel-scoped reload grants available across canvas close and rotate browser sessions whenever a renderer authenticates.
- Persist selected devices per canvas instance and restore them after renderer or host restarts.
- Reauthenticate the shared web client after stale sessions and rebuild the VS Code host bridge after authentication, network, or WebSocket failures.
- Preserve explicit detach semantics by revoking credentials and selection only when the user detaches.
- Add shared lifecycle tests, VS Code recovery coverage, packaging checks, and updated documentation.

## Validation

- 266 .NET tests
- 23 VS Code unit tests
- VS Code 1.101 integration tests
- `git diff --check`

## Release note

The native host is shipped in prebuilt runtime archives. Those archives must be rebuilt through the Release runtimes workflow before publishing packages with this fix.