### PR TITLE
Keep virtual device boots headless

### DIFF
--- a/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
+++ b/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
@@ -590,7 +590,15 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		CancellationToken cancellationToken = default)
 	{
 		var avdId = DeviceIdentity.GetNativeId(deviceId);
-		if (FindRunning(avdId) is not null)
+		var instance = FindRunning(avdId);
+		if (instance?.IsHeadless == false)
+		{
+			await WaitForBootAsync(avdId, cancellationToken).ConfigureAwait(false);
+			InvalidateCache(avdId);
+			return await GetDeviceAsync(deviceId, cancellationToken).ConfigureAwait(false);
+		}
+
+		if (instance is not null)
 			await ShutdownAsync(deviceId, cancellationToken).ConfigureAwait(false);
 
 		await LaunchEmulatorAsync(

--- a/src/MobileCanvas.Android/EmulatorDiscoveryParser.cs
+++ b/src/MobileCanvas.Android/EmulatorDiscoveryParser.cs
@@ -25,6 +25,17 @@ internal sealed record EmulatorInstance
 	public bool HasGrpc => GrpcPort > 0;
 
 	/// <summary>
+	/// Whether the process was launched without a native emulator window. Null means the discovery
+	/// file did not record a command line, so callers cannot safely assume either mode.
+	/// </summary>
+	public bool? IsHeadless =>
+		CommandLine is { Length: > 0 } commandLine
+			? commandLine
+				.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)
+				.Any(argument => argument.Trim('"').Equals("-no-window", StringComparison.OrdinalIgnoreCase))
+			: null;
+
+	/// <summary>
 	/// Whether the emulator was launched with host GPU acceleration. Software rendering drops
 	/// <c>streamScreenshot</c> from ~50 FPS to ~3 FPS, so this is surfaced as a diagnostic rather
 	/// than left to look like a bug in the stream.

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -389,7 +389,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 				framebufferUnavailableReason = exception.Message;
 			}
 
-			var windowResult = await FindCaptureWindowAsync(deviceId, device.NativeId, cancellationToken)
+			var windowResult = await FindCaptureWindowAsync(device.NativeId, cancellationToken)
 				.ConfigureAwait(false);
 			screenCaptureUnavailableReason = windowResult.FailureReason;
 			if (windowResult.Window is not null)
@@ -442,13 +442,11 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	}
 
 	private async Task<CaptureWindowResult> FindCaptureWindowAsync(
-		string deviceId,
 		string nativeId,
 		CancellationToken cancellationToken)
 	{
-		// Without Accessibility the helper cannot read window UDIDs, so no window can ever match.
-		// Checking first avoids a pointless reveal (which activates Simulator.app and retargets its
-		// displayed device) followed by ten failed retries, and reports the real cause.
+		// Live capture must not turn a headless boot into a visible Simulator.app window. An already
+		// visible window remains a valid fallback, but opening one is reserved for RevealAsync.
 		var permissions = await ScreenCaptureHelper.GetDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
 		if (!permissions.ScreenRecordingGranted)
 		{
@@ -463,34 +461,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 				"Grant Accessibility permission so the device screen can be located precisely.");
 		}
 
-		var result = await MatchWindowAsync(nativeId, cancellationToken).ConfigureAwait(false);
-		if (result.Window is not null)
-			return result;
-
-		// ScreenCaptureKit can only capture a window that exists, so a booted device whose window
-		// was closed or is showing another simulator needs Simulator.app brought forward first.
-		try
-		{
-			await RevealAsync(deviceId, cancellationToken).ConfigureAwait(false);
-		}
-		catch (Exception exception) when (exception is not OperationCanceledException)
-		{
-			return new CaptureWindowResult(null, exception.Message);
-		}
-
-		for (var attempt = 0; attempt < 10; attempt++)
-		{
-			await Task.Delay(300, cancellationToken).ConfigureAwait(false);
-			result = await MatchWindowAsync(nativeId, cancellationToken).ConfigureAwait(false);
-			if (result.Window is not null)
-				return result;
-		}
-
-		return result.FailureReason is not null
-			? result
-			: new CaptureWindowResult(
-				null,
-				"Simulator.app is not showing a window for this device, so ScreenCaptureKit cannot capture it.");
+		return await MatchWindowAsync(nativeId, cancellationToken).ConfigureAwait(false);
 	}
 
 	private async Task<CaptureWindowResult> MatchWindowAsync(
@@ -502,13 +473,17 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		{
 			return new CaptureWindowResult(
 				null,
-				"No simulator windows are visible to ScreenCaptureKit. Grant Screen Recording permission.");
+				"No simulator windows are open. Use Show simulator window to make this fallback available.");
 		}
 
 		var match = windows.FirstOrDefault(window =>
 			string.Equals(window.Udid, nativeId, StringComparison.OrdinalIgnoreCase));
 		if (match is null)
-			return default;
+		{
+			return new CaptureWindowResult(
+				null,
+				"Simulator.app is not showing this device. Use Show simulator window to make this fallback available.");
+		}
 
 		if (!match.HasExactGeometry)
 		{

--- a/tests/MobileCanvas.Tests/EmulatorDiscoveryParserTests.cs
+++ b/tests/MobileCanvas.Tests/EmulatorDiscoveryParserTests.cs
@@ -73,6 +73,25 @@ public sealed class EmulatorDiscoveryParserTests
 		Assert.Equal("abc123", instance?.GrpcToken);
 	}
 
+	[Theory]
+	[InlineData("\"emulator\" \"-avd\" \"X\" \"-no-window\"", true)]
+	[InlineData("emulator -avd X -no-window", true)]
+	[InlineData("\"emulator\" \"-avd\" \"X\" \"-gpu\" \"host\"", false)]
+	public void Parse_ReportsWhetherTheEmulatorHasANativeWindow(string commandLine, bool expected)
+	{
+		var instance = EmulatorDiscoveryParser.Parse($"avd.id=X\ncmdline={commandLine}");
+
+		Assert.Equal(expected, instance?.IsHeadless);
+	}
+
+	[Fact]
+	public void Parse_LeavesWindowModeUnknownWithoutACommandLine()
+	{
+		var instance = EmulatorDiscoveryParser.Parse("avd.id=X");
+
+		Assert.Null(instance?.IsHeadless);
+	}
+
 	/// <summary>
 	/// Software rendering drops the stream from ~50 FPS to ~3 FPS, which looks exactly like a broken
 	/// encoder, so it is detected from the recorded launch command and surfaced as a diagnostic.

--- a/vscode/test/canvas-state.test.mjs
+++ b/vscode/test/canvas-state.test.mjs
@@ -124,6 +124,20 @@ test("authenticates before reconnecting a resumed panel", async () => {
   assert.deepEqual(calls, ["authenticate", "resume"]);
 });
 
+test("refreshes device state before reconnecting a resumed panel", async () => {
+  const calls = [];
+
+  const result = await resumeAuthenticatedPanel({
+    authenticate: async () => calls.push("authenticate"),
+    isActive: () => true,
+    refresh: async () => calls.push("refresh"),
+    resume: () => calls.push("resume"),
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, ["authenticate", "refresh", "resume"]);
+});
+
 test("does not reconnect a panel hidden while authentication is pending", async () => {
   let finishAuthentication;
   let active = true;
@@ -141,6 +155,29 @@ test("does not reconnect a panel hidden while authentication is pending", async 
 
   active = false;
   finishAuthentication();
+  assert.equal(await result, false);
+  assert.equal(resumed, false);
+});
+
+test("does not reconnect a panel hidden while device state refreshes", async () => {
+  let finishRefresh;
+  let active = true;
+  let resumed = false;
+  const refresh = new Promise((resolve) => {
+    finishRefresh = resolve;
+  });
+  const result = resumeAuthenticatedPanel({
+    authenticate: async () => {},
+    isActive: () => active,
+    refresh: () => refresh,
+    resume: () => {
+      resumed = true;
+    },
+  });
+
+  await Promise.resolve();
+  active = false;
+  finishRefresh();
   assert.equal(await result, false);
   assert.equal(resumed, false);
 });

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -19,9 +19,12 @@ export function clearStoredDeviceId(storage, instanceId) {
 export async function resumeAuthenticatedPanel({
   authenticate,
   isActive,
+  refresh = async () => {},
   resume,
 }) {
   await authenticate();
+  if (!isActive()) return false;
+  await refresh();
   if (!isActive()) return false;
   resume();
   return true;

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -2432,20 +2432,17 @@ function setPanelVisible(visible) {
     return;
   }
   if (!state.detached) {
-    if (transport) {
-      startStream();
-      connectAutomationEvents();
-      return;
-    }
     const isActive = () =>
       panelVisibilityVersion === visibilityVersion
       && state.panelVisible
       && !state.detached;
     void resumeAuthenticatedPanel({
-      authenticate: () => api("/api/v1/status"),
+      authenticate: () => transport ? Promise.resolve() : api("/api/v1/status"),
       isActive,
+      // A device can finish booting while its host session is hidden. Re-read its state before
+      // deciding whether a stream can start instead of reconnecting from the stale "booting" record.
+      refresh,
       resume: () => {
-        startStream();
         connectAutomationEvents();
       },
     }).catch((error) => {


### PR DESCRIPTION
Booting an iOS simulator from Mobile Canvas could unexpectedly open Simulator.app when the preferred framebuffer stream fell back to window capture. Panels could also retain stale `booting` state after being hidden during startup, leaving the stream stuck on Connecting.

This change:
- keeps iOS streaming headless by using ScreenCaptureKit only when a matching window is already open; the explicit Show device window action is now the only reveal path
- preserves Android's `-no-window` boot behavior and avoids restarting emulators that already have a visible native window
- refreshes catalog and selected-device state before reconnecting a resumed GitHub canvas or VS Code view
- adds coverage for Android window-mode discovery and panel resume races

Tests: `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --no-restore -v minimal`; `npm --prefix vscode run build --silent`; `npm --prefix vscode run test:unit --silent`