### PR TITLE
Focus the requested simulator when reveal hits a running Simulator.app

### DIFF
--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -193,12 +193,56 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	public async Task<DeviceTarget> RevealAsync(string deviceId, CancellationToken cancellationToken = default)
 	{
 		var device = await BootAsync(deviceId, cancellationToken).ConfigureAwait(false);
+		// `--args` are only handed to Simulator.app when `open` launches it, so a reveal against an
+		// already-running instance just activates the app and leaves the requested device unfocused.
+		// Sample the state before activating so the follow-up only runs when it is actually needed.
+		var wasRunning = await IsSimulatorRunningAsync(cancellationToken).ConfigureAwait(false);
 		var arguments = new[] { "-a", "Simulator", "--args", "-CurrentDeviceUDID", device.NativeId };
 		var result = await _processRunner.RunAsync(
 			new ProcessRequest("open", arguments),
 			cancellationToken).ConfigureAwait(false);
 		EnsureSuccess("open", arguments, result);
+		if (wasRunning)
+			await FocusSimulatorWindowAsync(device, cancellationToken).ConfigureAwait(false);
 		return device;
+	}
+
+	private async Task<bool> IsSimulatorRunningAsync(CancellationToken cancellationToken)
+	{
+		try
+		{
+			var result = await _processRunner.RunAsync(
+				new ProcessRequest("pgrep", ["-x", "Simulator"]),
+				cancellationToken).ConfigureAwait(false);
+			return result.ExitCode == 0;
+		}
+		catch (Exception exception) when (exception is not OperationCanceledException)
+		{
+			// Treat an unusable pgrep as "not running" so reveal falls back to plain `open`.
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Best-effort focus of an already-running Simulator.app, which needs Accessibility. Reveal has
+	/// already activated the app by this point, so a denied permission degrades to the old behaviour
+	/// rather than failing the call.
+	/// </summary>
+	private async Task FocusSimulatorWindowAsync(DeviceTarget device, CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(device.Name) || string.IsNullOrWhiteSpace(device.RuntimeName))
+			return;
+		var script = SimulatorWindowFocus.BuildScript(device.Name, device.RuntimeName);
+		try
+		{
+			await _processRunner.RunAsync(
+				new ProcessRequest("osascript", ["-e", script]),
+				cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception exception) when (exception is not OperationCanceledException)
+		{
+			// Ignored: the window simply stays where it was.
+		}
 	}
 
 	public async Task TapAsync(

--- a/src/MobileCanvas.iOS/SimulatorWindowFocus.cs
+++ b/src/MobileCanvas.iOS/SimulatorWindowFocus.cs
@@ -1,0 +1,49 @@
+namespace MobileCanvas.iOS;
+
+/// <summary>
+/// Builds the System Events script that brings a Simulator.app device window forward.
+/// </summary>
+/// <remarks>
+/// <c>open -a Simulator --args -CurrentDeviceUDID &lt;udid&gt;</c> only delivers <c>--args</c> when
+/// <c>open</c> actually launches Simulator.app. If it is already running the flag is ignored, so a
+/// reveal neither raises the requested window nor re-attaches a device that is booted but detached.
+/// Simulator.app advertises AppleScript support, but Apple Events to it time out (-1712), so
+/// Accessibility is the only usable lever. This deliberately stops at raising an existing window:
+/// driving the File &gt; Open Simulator menu would also re-attach a detached device, but opening
+/// menus steals keyboard and mouse focus from whatever the user is doing. When there is no window
+/// to raise the reveal simply leaves Simulator.app frontmost.
+/// </remarks>
+public static class SimulatorWindowFocus
+{
+	/// <summary>Separator Simulator.app places between the device name and runtime in window titles.</summary>
+	private const string TitleSeparator = " \u2013 ";
+
+	/// <summary>Reproduces the window title Simulator.app gives a device, e.g. <c>iPhone 17 – iOS 27.0</c>.</summary>
+	public static string BuildWindowTitle(string deviceName, string runtimeName) =>
+		$"{deviceName}{TitleSeparator}{runtimeName}";
+
+	/// <summary>
+	/// Builds an AppleScript that raises <paramref name="deviceName"/>'s window when Simulator.app
+	/// is showing one, and does nothing otherwise.
+	/// </summary>
+	public static string BuildScript(string deviceName, string runtimeName)
+	{
+		var title = Escape(BuildWindowTitle(deviceName, runtimeName));
+		return $"""
+			tell application "System Events"
+				tell process "Simulator"
+					if exists window "{title}" then
+						set frontmost to true
+						perform action "AXRaise" of window "{title}"
+					end if
+				end tell
+			end tell
+			""";
+	}
+
+	// Device names are user supplied through `simctl create`, so they can contain quotes.
+	private static string Escape(string value) =>
+		value
+			.Replace("\\", "\\\\", StringComparison.Ordinal)
+			.Replace("\"", "\\\"", StringComparison.Ordinal);
+}

--- a/tests/MobileCanvas.Tests/SimulatorRevealTests.cs
+++ b/tests/MobileCanvas.Tests/SimulatorRevealTests.cs
@@ -1,0 +1,132 @@
+using MobileCanvas.Core;
+using MobileCanvas.iOS;
+
+namespace MobileCanvas.Tests;
+
+public sealed class SimulatorRevealTests
+{
+	private const string DeviceId = "ios:core-simulator:ABCD-1234";
+
+	private const string DevicesJson = """
+	{
+	  "runtimes": [{
+	    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+	    "name": "iOS 18.6",
+	    "version": "18.6",
+	    "isAvailable": true,
+	    "supportedArchitectures": ["arm64"],
+	    "supportedDeviceTypes": [{
+	      "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"
+	    }]
+	  }],
+	  "devicetypes": [{
+	    "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+	    "name": "iPhone 16 Pro",
+	    "productFamily": "iPhone"
+	  }],
+	  "devices": {
+	    "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [{
+	      "name": "UI Test iPhone",
+	      "udid": "ABCD-1234",
+	      "state": "Booted",
+	      "isAvailable": true,
+	      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"
+	    }]
+	  }
+	}
+	""";
+
+	[Fact]
+	public void BuildWindowTitle_MatchesSimulatorsEnDashFormat()
+	{
+		Assert.Equal(
+			"iPhone 17 \u2013 iOS 27.0",
+			SimulatorWindowFocus.BuildWindowTitle("iPhone 17", "iOS 27.0"));
+	}
+
+	[Fact]
+	public void BuildScript_RaisesTheDeviceWindowWithoutDrivingMenus()
+	{
+		var script = SimulatorWindowFocus.BuildScript("iPhone 17", "iOS 27.0");
+
+		Assert.Contains("exists window \"iPhone 17 \u2013 iOS 27.0\"", script);
+		Assert.Contains("perform action \"AXRaise\" of window \"iPhone 17 \u2013 iOS 27.0\"", script);
+		// Opening menus steals keyboard and mouse focus, so a missing window is left alone.
+		Assert.DoesNotContain("menu", script, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void BuildScript_EscapesQuotesInDeviceNames()
+	{
+		var script = SimulatorWindowFocus.BuildScript("My \"Test\" Phone", "iOS 27.0");
+
+		Assert.Contains("window \"My \\\"Test\\\" Phone \u2013 iOS 27.0\"", script);
+		Assert.DoesNotContain("window \"My \"Test\"", script);
+	}
+
+	[Fact]
+	public async Task RevealAsync_LaunchesSimulatorWithTheDeviceWhenItIsNotRunning()
+	{
+		var runner = new ScriptedProcessRunner(DevicesJson) { SimulatorRunning = false };
+		await using var backend = new IosSimulatorBackend(runner);
+
+		await backend.RevealAsync(DeviceId, CancellationToken.None);
+
+		var open = Assert.Single(runner.Requests, request => request.FileName == "open");
+		Assert.Equal(["-a", "Simulator", "--args", "-CurrentDeviceUDID", "ABCD-1234"], open.Arguments);
+		// `--args` already selects the device on launch, so no Accessibility work is needed.
+		Assert.DoesNotContain(runner.Requests, request => request.FileName == "osascript");
+	}
+
+	[Fact]
+	public async Task RevealAsync_FocusesTheWindowWhenSimulatorIsAlreadyRunning()
+	{
+		var runner = new ScriptedProcessRunner(DevicesJson) { SimulatorRunning = true };
+		await using var backend = new IosSimulatorBackend(runner);
+
+		await backend.RevealAsync(DeviceId, CancellationToken.None);
+
+		var script = Assert.Single(runner.Requests, request => request.FileName == "osascript");
+		Assert.Equal("-e", script.Arguments[0]);
+		Assert.Equal(
+			SimulatorWindowFocus.BuildScript("UI Test iPhone", "iOS 18.6"),
+			script.Arguments[1]);
+	}
+
+	[Fact]
+	public async Task RevealAsync_SucceedsWhenAccessibilityIsUnavailable()
+	{
+		var runner = new ScriptedProcessRunner(DevicesJson)
+		{
+			SimulatorRunning = true,
+			OsascriptThrows = true,
+		};
+		await using var backend = new IosSimulatorBackend(runner);
+
+		var device = await backend.RevealAsync(DeviceId, CancellationToken.None);
+
+		// Reveal already brought Simulator.app forward, so a denied permission must not fail the call.
+		Assert.Equal("ABCD-1234", device.NativeId);
+	}
+
+	private sealed class ScriptedProcessRunner(string devicesJson) : IProcessRunner
+	{
+		public bool SimulatorRunning { get; init; }
+		public bool OsascriptThrows { get; init; }
+		public List<ProcessRequest> Requests { get; } = [];
+
+		public Task<ProcessResult> RunAsync(
+			ProcessRequest request,
+			CancellationToken cancellationToken = default)
+		{
+			Requests.Add(request);
+			if (request.FileName == "xcrun" && request.Arguments.Contains("list"))
+				return Task.FromResult(new ProcessResult(0, devicesJson, ""));
+			if (request.FileName == "pgrep")
+				return Task.FromResult(new ProcessResult(SimulatorRunning ? 0 : 1, "", ""));
+			if (request.FileName == "osascript" && OsascriptThrows)
+				throw new InvalidOperationException("osascript is unavailable.");
+			return Task.FromResult(new ProcessResult(0, "", ""));
+		}
+	}
+}


### PR DESCRIPTION
This started as an investigation into iOS simulators showing a window on boot. That turned out not to be our bug, but it surfaced a real one in `reveal`.

## The bug

`RevealAsync` runs `open -a Simulator --args -CurrentDeviceUDID <udid>`. `open` only hands `--args` to an app when it actually *launches* it. Against an already-running Simulator.app it just activates the app, so the flag is silently dropped and the requested device stays buried behind whatever window was already frontmost. Reveal appeared to do nothing.

## The fix

Sample whether Simulator.app is already running (`pgrep -x Simulator`) *before* calling `open`, and when it is, follow up with an Accessibility script that raises that device's window by title.

Everything here is best-effort and degrades to the previous behaviour of simply bringing Simulator.app forward:

- Simulator.app not running: `--args` works as it always did, and no Accessibility work happens at all.
- `pgrep` unusable: treated as "not running", so we fall back to plain `open`.
- Accessibility denied: the `osascript` failure is swallowed. The app has still been activated.

## Things worth knowing on review

**The boot path was already headless.** Verified end to end: with Simulator.app closed, `simctl boot`, `idb_companion`, and screenshots all run with no window. A *running* Simulator.app auto-attaches a window to any externally booted device, and Apple offers no opt-out (`simctl` has no flag, `AttachBootedOnStart` only applies at launch, Apple Events to Simulator time out with -1712). No boot-path change was needed.

**I deliberately stopped short of re-attaching detached devices.** Driving `File > Open Simulator > <runtime> > <device>` does work, and it is the only way to give a booted-but-detached device a window back. I prototyped it and then dropped it: opening menus steals keyboard and mouse focus from whatever the user is doing, which is worse than the thing it fixes. `SimulatorRevealTests` asserts the generated script contains no `menu` at all so this cannot creep back in.

**Accessibility is the only lever available.** Simulator.app advertises AppleScript support and ships an sdef, but Apple Events to it time out even with `NSAppleScriptEnabled`. `defaults write com.apple.iphonesimulator CurrentDeviceUDID` also fails, since the app owns and rewrites that key while running.

**Window titles use an en dash** (`iPhone 17 - iOS 27.0` is really U+2013), encoded as `\u2013` in source. Device names come from `simctl create` and can contain quotes, so they are escaped before interpolation into the script.

`reveal` is still "sticky": it leaves Simulator.app running, so every later boot in that session shows a window. Left alone by design.

## Verification

293 tests pass, including 6 new ones covering script generation, quote escaping, and all three reveal paths. Also verified live on macOS that reveal focuses a background device.