### PR TITLE
Publish the VS Code extension to the Marketplace on release

### DIFF
--- a/.github/workflows/marketplace-identity.yml
+++ b/.github/workflows/marketplace-identity.yml
@@ -1,0 +1,92 @@
+# Reports who the Marketplace sees when the release workflow signs in, and
+# whether that identity is allowed to publish.
+#
+# Authorising the identity is a chicken-and-egg problem: a Marketplace publisher
+# grants access to an Azure DevOps profile id, and the only way to learn an
+# identity's profile id is to ask Azure DevOps while authenticated as it. That
+# needs a workflow, because the federated credential only trusts GitHub. So this
+# runs the lookup and prints the id to paste into the publisher's member list.
+#
+# It stays useful after that one-time setup: it is the same sign-in the release
+# uses, in the same environment, so it answers "is publishing broken because of
+# credentials?" without cutting a release to find out.
+name: Marketplace identity
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  identity:
+    name: Who can publish
+    runs-on: ubuntu-latest
+    # Must match the release job: an environment changes the subject GitHub puts
+    # in the OIDC token, so signing in from anywhere else would prove nothing
+    # about whether the release can sign in.
+    environment: vscode-marketplace
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: vscode/package-lock.json
+
+      - name: Install vsce
+        run: npm ci --prefix vscode --ignore-scripts
+
+      - name: Sign in to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # 499b84ac-1321-427f-aa17-267ca6975798 is Azure DevOps. The profile id it
+      # returns is the identity's name in Marketplace terms, and is what the
+      # publisher's member list is keyed on -- the Entra client id is not.
+      - name: Look up the Azure DevOps profile
+        id: profile
+        run: |
+          profile=$(az rest \
+            --url https://app.vssps.visualstudio.com/_apis/profile/profiles/me \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798)
+          echo "$profile"
+          echo "id=$(echo "$profile" | jq -r .id)" >> "$GITHUB_OUTPUT"
+
+      # Reads the publisher's role assignments, which answers a different
+      # question than signing in did: the sign-in proves the identity exists,
+      # this proves the publisher has let it in. Not fatal, because reporting
+      # that it has not is the whole point of running this before setup.
+      - name: Check publish access
+        id: access
+        continue-on-error: true
+        run: npm exec --prefix vscode -- vsce verify-pat redth --azure-credential
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+
+      - name: Summarise
+        run: |
+          {
+            echo "## Marketplace identity"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Entra client id | \`${{ secrets.AZURE_CLIENT_ID }}\` |"
+            echo "| Azure DevOps profile id | \`${{ steps.profile.outputs.id }}\` |"
+            echo "| Can publish as \`redth\` | ${{ steps.access.outcome == 'success' && 'yes' || 'no' }} |"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ steps.access.outcome }}" != "success" ]; then
+            {
+              echo "Add \`${{ steps.profile.outputs.id }}\` as a **Contributor**"
+              echo "member of the \`redth\` publisher at"
+              echo "<https://marketplace.visualstudio.com/manage/publishers/redth>,"
+              echo "then run this again."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,9 +303,15 @@ jobs:
       (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-'))
       || (inputs.publish_marketplace && inputs.prerelease_tag == '')
     runs-on: ubuntu-latest
-    # Holds VSCE_PAT, and gives the publish a place to require an approval
-    # without gating the rest of the release behind one.
+    # Holds the Entra identity's ids, and gives the publish a place to require
+    # an approval without gating the rest of the release behind one.
     environment: vscode-marketplace
+    permissions:
+      # Mints the OIDC token azure/login exchanges for the identity. Declaring
+      # any permission here replaces the workflow's defaults, so contents has to
+      # be restated for checkout and `gh release view`.
+      contents: read
+      id-token: write
     env:
       # A tag run knows its own tag. A dispatch is normally re-running a publish
       # that failed, either from the tag itself or from a branch with the
@@ -335,6 +341,19 @@ jobs:
       - name: Install vsce
         run: npm ci --prefix vscode --ignore-scripts
 
+      # Azure DevOps retires global PATs on 1 December 2026, so the publish
+      # authenticates as an Entra identity instead. vsce resolves that token
+      # through a chained credential that has no workload-identity link in it,
+      # so the OIDC exchange cannot be handed to vsce directly -- azure/login
+      # performs the exchange and leaves a logged-in Azure CLI behind, which is
+      # the credential in that chain vsce does find.
+      - name: Sign in to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       # The thin VSIX downloads its runtime from the release assets on first
       # use, so publishing before those exist would ship an extension that
       # cannot start. `needs: bundle` covers the tag path; this also catches a
@@ -357,5 +376,9 @@ jobs:
 
       - name: Publish
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          # vsce asks its credential chain for a token in this tenant. Only the
+          # tenant is set: giving the chain a client id as well would send it
+          # down the environment-credential path first, which has no secret to
+          # go with it.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: node scripts/publish-vscode.mjs --version "$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ on:
         description: Open a PR with the refreshed runtimes
         type: boolean
         default: true
+      publish_marketplace:
+        description: Publish the VS Code extension to the Marketplace
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -289,3 +293,69 @@ jobs:
             Directory.Build.props
             .github/plugin/plugin.json
             .github/plugin/marketplace.json
+
+  publish-vscode:
+    name: VS Code Marketplace
+    needs: bundle
+    # A tag publishes; a dispatch has to ask. Prerelease dispatches never reach
+    # here, because the Marketplace has no concept of a release candidate.
+    if: >-
+      (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-'))
+      || (inputs.publish_marketplace && inputs.prerelease_tag == '')
+    runs-on: ubuntu-latest
+    # Holds VSCE_PAT, and gives the publish a place to require an approval
+    # without gating the rest of the release behind one.
+    environment: vscode-marketplace
+    env:
+      # A tag run knows its own tag. A dispatch is normally re-running a publish
+      # that failed, either from the tag itself or from a branch with the
+      # version to republish, so fall back to the version it was given.
+      RELEASE_TAG: >-
+        ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name
+        || format('v{0}', inputs.version) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: vscode/package-lock.json
+
+      # Publishes exactly what the release built and shipped, rather than
+      # rebuilding it: a rebuild here could differ from the VSIXs users can
+      # already download from the release.
+      - uses: actions/download-artifact@v4
+        with:
+          name: mobile-canvas-vscode
+          path: .build
+
+      # The extension's own devDependencies are what pin vsce; --ignore-scripts
+      # because nothing here needs the build hooks.
+      - name: Install vsce
+        run: npm ci --prefix vscode --ignore-scripts
+
+      # The thin VSIX downloads its runtime from the release assets on first
+      # use, so publishing before those exist would ship an extension that
+      # cannot start. `needs: bundle` covers the tag path; this also catches a
+      # dispatch pointed at a version that was never released.
+      - name: Require published release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test -n "$RELEASE_TAG" || {
+            echo "no release tag: dispatch this from a tag, or pass a version" >&2
+            exit 1
+          }
+          gh release view "$RELEASE_TAG" --json assets >/dev/null
+
+      - name: Verify packages
+        run: |
+          for vsix in .build/mobile-canvas-vscode-*.vsix; do
+            node scripts/verify-vsix.mjs "$vsix"
+          done
+
+      - name: Publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: node scripts/publish-vscode.mjs --version "$RELEASE_TAG"

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -278,13 +278,50 @@ artifact cannot contain its own hash. Expect it to trail `git log` by one.
 4. CI packages bundled and thin Copilot plugins, bundled and thin universal
    VSIXs, and up to six target VSIXs.
 5. A `v*` tag publishes every file to the corresponding GitHub Release.
-6. A manual run can still open a PR refreshing the compatibility bundle.
+6. A `v*` tag then publishes the VS Code extension to the Marketplace.
+7. A manual run can still open a PR refreshing the compatibility bundle.
 
 Before merging a distribution change, manually dispatch the workflow with a new
 numeric `version`, a unique `prerelease_tag` matching `v*-rc.*`, and `commit`
 disabled. This creates an isolated GitHub prerelease from the branch so the thin
 Copilot plugin and thin VSIX can be installed against real release URLs. Delete
 the prerelease and tag after the smoke test.
+
+### Publishing to the VS Code Marketplace
+
+The `publish-vscode` job publishes `scripts/publish-vscode.mjs`, which uploads
+the six target VSIXs plus the **thin** universal VSIX built by the same run. The
+Marketplace serves each target package to the platform it matches and falls back
+to the package carrying no target, so the thin package is what reaches
+`linux-armhf`, Alpine, and the web — the bundled universal VSIX is not published
+because a version may carry only one untargeted package, and a 73 MiB download
+containing five unusable runtimes is a worse default than a first-use fetch.
+
+The job needs one secret, `VSCE_PAT`, in a `vscode-marketplace` environment.
+That is an Azure DevOps personal access token created under the same Microsoft
+account that owns the `redth` publisher, with **Organization** set to *All
+accessible organizations* and **Scopes** set to *Marketplace → Manage*. Anything
+narrower fails at publish time. `vsce` reads `VSCE_PAT` from the environment;
+if it is missing, `vsce` prompts, so the script fails first rather than hanging
+the runner. Putting the secret in an environment rather than the repository also
+allows a required reviewer on the publish without gating the rest of the
+release. Azure DevOps caps token lifetime at one year, so the token needs
+rotating; workload identity federation is the longer-term alternative, but its
+documented setup targets Azure Pipelines.
+
+The job is skipped for `v*-rc.*` prereleases because the Marketplace accepts
+only `major.minor.patch` — semver prerelease tags are rejected — and
+`publish-vscode.mjs` fails with that explanation rather than letting `vsce`
+reject the upload after some targets have already shipped. Re-running the job is
+safe: it asks `vsce show` which version and target pairs already exist and
+publishes only the remainder, which is also how a partially failed publish
+recovers.
+
+`scripts/verify-vsix.mjs` enforces the Marketplace's image rules at packaging
+time: the icon and any badge may not be an SVG, and readme images must be
+non-SVG `https` URLs. The rules cover only the manifest icon, badges, and readme
+images, which is why `vscode/media/activitybar.svg` stays an SVG — a contributed
+icon is exempt, and the activity bar needs to tint it.
 
 `scripts/verify-bundle.mjs` checks every local archive on any host. CI also
 warns when the manifest source hash has drifted behind `src/`.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -297,17 +297,30 @@ to the package carrying no target, so the thin package is what reaches
 because a version may carry only one untargeted package, and a 73 MiB download
 containing five unusable runtimes is a worse default than a first-use fetch.
 
-The job needs one secret, `VSCE_PAT`, in a `vscode-marketplace` environment.
-That is an Azure DevOps personal access token created under the same Microsoft
-account that owns the `redth` publisher, with **Organization** set to *All
-accessible organizations* and **Scopes** set to *Marketplace → Manage*. Anything
-narrower fails at publish time. `vsce` reads `VSCE_PAT` from the environment;
-if it is missing, `vsce` prompts, so the script fails first rather than hanging
-the runner. Putting the secret in an environment rather than the repository also
-allows a required reviewer on the publish without gating the rest of the
-release. Azure DevOps caps token lifetime at one year, so the token needs
-rotating; workload identity federation is the longer-term alternative, but its
-documented setup targets Azure Pipelines.
+The job authenticates as an Entra ID workload identity rather than a personal
+access token, because Azure DevOps retires global PATs on 1 December 2026. Set
+three values in a `vscode-marketplace` environment — `AZURE_CLIENT_ID`,
+`AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` — for a user-assigned managed
+identity holding a federated credential that trusts this repository. Using an
+environment rather than repository secrets also allows a required reviewer on
+the publish without gating the rest of the release.
+
+Two details are easy to get wrong. The federated credential's **subject must be
+`repo:Redth/mobile-canvas-ghcp:environment:vscode-marketplace`**, because naming
+an environment is what GitHub puts in the token's subject — a credential scoped
+to a branch ref will not match. And the identity must be a **Contributor member
+of the `redth` publisher**, which is keyed on its *Azure DevOps profile id*, not
+its Entra client id. Run the **Marketplace identity** workflow to read that
+profile id; it signs in exactly as the release does and reports whether the
+identity can publish yet, so it is also the fastest way to tell a broken
+credential from a missing membership without cutting a release.
+
+`azure/login` does the OIDC exchange rather than the token being handed to
+`vsce` directly, because `vsce` resolves credentials through a chain that
+contains no workload-identity link. What it does contain is the Azure CLI, so
+signing the CLI in is what makes `vsce publish --azure-credential` work.
+`VSCE_PAT` still takes precedence if it is set, which keeps a local publish
+possible until PATs are gone.
 
 The job is skipped for `v*-rc.*` prereleases because the Marketplace accepts
 only `major.minor.patch` — semver prerelease tags are rejected — and

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "icons": "node scripts/generate-icons.mjs",
     "package:plugin": "node scripts/prepare-plugin.mjs",
     "package:plugin:thin": "node scripts/prepare-plugin.mjs --thin",
-    "package:runtimes": "node scripts/package-runtime-assets.mjs"
+    "package:runtimes": "node scripts/package-runtime-assets.mjs",
+    "publish:vscode": "node scripts/publish-vscode.mjs"
   },
   "dependencies": {
     "@github/copilot-sdk": "latest"

--- a/scripts/publish-vscode.mjs
+++ b/scripts/publish-vscode.mjs
@@ -55,10 +55,31 @@ if (!RELEASABLE.test(version)) {
     `the marketplace does not accept prerelease versions, so ${version} cannot be published`,
   );
 }
-if (!dryRun && !process.env.VSCE_PAT) {
-  // vsce prompts for a token it cannot read, which on a runner is a job that
-  // hangs until it times out rather than one that fails.
-  throw new Error("VSCE_PAT is not set, so vsce would block prompting for it");
+// Azure DevOps retires global personal access tokens on 1 December 2026, so
+// Entra ID is the default and VSCE_PAT is the fallback that still works until
+// then. vsce reads VSCE_PAT from the environment on its own; --azure-credential
+// makes it resolve a token through a chained credential instead, which on a
+// runner is satisfied by the Azure CLI login that azure/login leaves behind.
+const authArguments = process.env.VSCE_PAT ? [] : ["--azure-credential"];
+
+if (!dryRun) {
+  // Publishing seven packages one call at a time means an unauthorised identity
+  // fails on the first and leaves nothing behind, but publishing is not the
+  // cheapest way to discover that. verify-pat reads the publisher's role
+  // assignments, so it separates "the credential did not resolve" from "the
+  // credential resolved but is not a member of this publisher" before anything
+  // is uploaded.
+  const publisher = id.split(".")[0];
+  console.log(`verifying publish access to ${publisher}`);
+  runVsce(["verify-pat", publisher, ...authArguments], {
+    onFailure: authArguments.length > 0
+      ? `could not publish as ${publisher}. Either the Entra identity did not `
+        + "resolve, or it resolved and is not a member of the publisher -- add "
+        + "its Azure DevOps profile id as a Contributor at "
+        + `https://marketplace.visualstudio.com/manage/publishers/${publisher} `
+        + "(run the Marketplace identity workflow to read that id)"
+      : `VSCE_PAT cannot publish as ${publisher}`,
+  });
 }
 
 const published = publishedPackages(id);
@@ -83,14 +104,33 @@ if (pending.length === 0) {
   );
 
   if (!dryRun) {
-    execFileSync(
-      npm,
-      ["exec", "--", "vsce", "publish", "--packagePath", ...pending.map((entry) => entry.path)],
-      { cwd: extensionRoot, stdio: "inherit" },
-    );
+    runVsce([
+      "publish",
+      ...authArguments,
+      "--packagePath",
+      ...pending.map((entry) => entry.path),
+    ], {
+      onFailure: "vsce could not publish. Anything already uploaded stays "
+        + "published, so re-running this job skips it and retries the rest",
+    });
   }
 
   summarise(packages, pending);
+}
+
+// vsce reports its own failures to stderr before exiting, so the value left to
+// add is what to do about it -- not a Node stack through child_process, which
+// is what an uncaught execFileSync error would print over the top of it.
+function runVsce(args, { onFailure }) {
+  try {
+    execFileSync(npm, ["exec", "--", "vsce", ...args], {
+      cwd: extensionRoot,
+      stdio: "inherit",
+    });
+  } catch {
+    console.error(`\n${onFailure}`);
+    process.exit(1);
+  }
 }
 
 // The release job uploads one artifact holding every VSIX it built, so the set

--- a/scripts/publish-vscode.mjs
+++ b/scripts/publish-vscode.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// Publishes the VS Code packages built by the release workflow to the
+// Marketplace.
+//
+//   publish-vscode.mjs                 publish everything not already published
+//   publish-vscode.mjs --version 1.2.3 refuse to publish anything else
+//   publish-vscode.mjs --dry-run       report what would be published
+//
+// What goes to the Marketplace is deliberately not what gets attached to the
+// GitHub Release. The Marketplace serves each target package to the platform it
+// matches and falls back to the package carrying no target for everything else,
+// so the set to publish is the six target packages plus the thin universal
+// VSIX, which downloads its runtime on first use. The bundled universal VSIX is
+// ~73 MiB because it carries all six runtimes at once; it stays a GitHub
+// Release download, both because a version may only carry one package with no
+// target and because handing every user five runtimes they cannot execute is a
+// worse default than a first-use download.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readVsixIdentity, withVsix } from "./vsix.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const buildDirectory = join(root, ".build");
+const extensionRoot = join(root, "vscode");
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const dryRun = process.argv.includes("--dry-run");
+const versionIndex = process.argv.indexOf("--version");
+// The workflow always passes --version so the command reads the same whether or
+// not it has one to pass, which means an empty value has to mean "no
+// expectation" rather than "expect the empty version".
+const expectedVersion = versionIndex >= 0
+  ? (process.argv[versionIndex + 1] ?? "").trim().replace(/^v/, "")
+  : "";
+
+// Marketplace versions are strictly major.minor.patch: "semver pre-release tags
+// are not supported". The release workflow can be dispatched with a v*-rc.*
+// prerelease to smoke-test artifacts against real release URLs, and that is a
+// GitHub-only concept -- saying so here beats a rejected upload after some of
+// the targets already went out.
+const RELEASABLE = /^\d+\.\d+\.\d+$/;
+
+const packages = collectPackages();
+const { id, version } = describe(packages);
+
+if (expectedVersion && version !== expectedVersion) {
+  throw new Error(
+    `packages carry version ${version} but the release is ${expectedVersion}`,
+  );
+}
+if (!RELEASABLE.test(version)) {
+  throw new Error(
+    `the marketplace does not accept prerelease versions, so ${version} cannot be published`,
+  );
+}
+if (!dryRun && !process.env.VSCE_PAT) {
+  // vsce prompts for a token it cannot read, which on a runner is a job that
+  // hangs until it times out rather than one that fails.
+  throw new Error("VSCE_PAT is not set, so vsce would block prompting for it");
+}
+
+const published = publishedPackages(id);
+const pending = packages.filter(
+  (entry) => !published.has(`${entry.version}\u0000${entry.target ?? ""}`),
+);
+const skipped = packages.length - pending.length;
+
+if (skipped > 0) {
+  // A publish that fails partway through has already shipped some targets, and
+  // the only useful thing to do about it is to run the job again. Re-publishing
+  // one that landed is rejected, so the ones that landed are dropped instead.
+  console.log(`${skipped} package(s) already published at ${version}`);
+}
+
+if (pending.length === 0) {
+  console.log(`${id} ${version} is already published`);
+  summarise(packages, []);
+} else {
+  console.log(
+    `publishing ${id} ${version}: ${pending.map(describeTarget).join(", ")}`,
+  );
+
+  if (!dryRun) {
+    execFileSync(
+      npm,
+      ["exec", "--", "vsce", "publish", "--packagePath", ...pending.map((entry) => entry.path)],
+      { cwd: extensionRoot, stdio: "inherit" },
+    );
+  }
+
+  summarise(packages, pending);
+}
+
+// The release job uploads one artifact holding every VSIX it built, so the set
+// to publish is read off disk rather than recomputed from the runtime manifest:
+// publishing something the release did not produce is the failure worth
+// avoiding, and matching the release's own filenames is what prevents it.
+function collectPackages() {
+  if (!existsSync(buildDirectory)) {
+    throw new Error(`no packages to publish: ${buildDirectory} does not exist`);
+  }
+
+  const found = readdirSync(buildDirectory)
+    .filter((name) => /^mobile-canvas-vscode-.+\.vsix$/.test(name))
+    .sort()
+    .map((name) => {
+      const path = join(buildDirectory, name);
+      return { path, ...withVsix(path, readVsixIdentity) };
+    });
+
+  if (found.length === 0) {
+    throw new Error(`no mobile-canvas-vscode-*.vsix packages in ${buildDirectory}`);
+  }
+
+  const universal = found.filter((entry) => entry.target === null);
+  if (universal.length > 1) {
+    throw new Error(
+      `only one package may omit a target platform, found ${universal
+        .map((entry) => basename(entry.path))
+        .join(", ")}`,
+    );
+  }
+  if (found.some((entry) => entry.target !== null) && universal.length === 0) {
+    throw new Error(
+      "no fallback package: platforms without a target package could not install the extension",
+    );
+  }
+
+  return found;
+}
+
+function describe(entries) {
+  const ids = new Set(entries.map((entry) => entry.id));
+  const versions = new Set(entries.map((entry) => entry.version));
+  if (ids.size !== 1 || versions.size !== 1) {
+    throw new Error(
+      `packages disagree: ${entries
+        .map((entry) => `${basename(entry.path)} is ${entry.id} ${entry.version}`)
+        .join(", ")}`,
+    );
+  }
+
+  return { id: [...ids][0], version: [...versions][0] };
+}
+
+// `vsce show` prints "undefined" rather than failing for an extension that has
+// never been published, so the first release has to read as an empty set rather
+// than as an error.
+function publishedPackages(extensionId) {
+  let output;
+  try {
+    output = execFileSync(npm, ["exec", "--", "vsce", "show", extensionId, "--json"], {
+      cwd: extensionRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+  } catch {
+    return new Set();
+  }
+
+  let listing;
+  try {
+    listing = JSON.parse(output);
+  } catch {
+    return new Set();
+  }
+
+  return new Set(
+    (listing?.versions ?? []).map(
+      (entry) => `${entry.version}\u0000${entry.targetPlatform ?? ""}`,
+    ),
+  );
+}
+
+function describeTarget(entry) {
+  return entry.target ?? "universal fallback";
+}
+
+function summarise(all, pending) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  const lines = ["## VS Code Marketplace", ""];
+  for (const entry of all) {
+    const state = dryRun
+      ? "would publish"
+      : pending.includes(entry)
+        ? "published"
+        : "already published";
+    const mib = (statSync(entry.path).size / 1024 / 1024).toFixed(1);
+    lines.push(
+      `- \`${describeTarget(entry)}\` -- ${state}, ${mib} MiB `
+      + `(\`${relative(root, entry.path)}\`)`,
+    );
+  }
+
+  console.log(lines.join("\n"));
+  if (summaryPath) {
+    appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+  }
+}

--- a/scripts/verify-vsix.mjs
+++ b/scripts/verify-vsix.mjs
@@ -1,18 +1,9 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
-import {
-  copyFileSync,
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  statSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { listFiles, verifyPublishableImages, withVsix } from "./vsix.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const vsix = resolve(process.argv[2] ?? join(root, ".build", "mobile-canvas-vscode.vsix"));
@@ -21,13 +12,7 @@ if (!existsSync(vsix)) {
   throw new Error(`VSIX does not exist: ${vsix}`);
 }
 
-const extracted = mkdtempSync(join(tmpdir(), "mobile-canvas-vsix-"));
-try {
-  extractVsix(vsix, extracted);
-  verifyExtracted(extracted);
-} finally {
-  rmSync(extracted, { recursive: true, force: true });
-}
+withVsix(vsix, verifyExtracted);
 
 function verifyExtracted(directory) {
   const entries = new Set(listFiles(directory));
@@ -97,6 +82,7 @@ function verifyExtracted(directory) {
   if (extensionPackage.icon !== "media/icon.png") {
     throw new Error("VSIX must declare the marketplace icon at media/icon.png.");
   }
+  verifyPublishableImages(extensionPackage, readEntry("extension/readme.md"));
   for (const name of [
     "mobileCanvas_selectedDevice",
     "mobileCanvas_screenshot",
@@ -121,45 +107,4 @@ function verifyExtracted(directory) {
   );
 }
 
-function extractVsix(source, destination) {
-  if (process.platform === "win32") {
-    const archive = join(destination, "mobile-canvas-vsix.zip");
-    copyFileSync(source, archive);
-    try {
-      execFileSync(
-        "powershell.exe",
-        [
-          "-NoLogo",
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          "Expand-Archive -LiteralPath $env:MC_VSIX -DestinationPath $env:MC_DEST -Force",
-        ],
-        {
-          env: { ...process.env, MC_VSIX: archive, MC_DEST: destination },
-          stdio: "inherit",
-        },
-      );
-    } finally {
-      rmSync(archive, { force: true });
-    }
-    return;
-  }
-  execFileSync("unzip", ["-q", source, "-d", destination]);
-}
 
-function listFiles(rootDirectory) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile()) {
-        files.push(relative(rootDirectory, path).split(sep).join("/"));
-      }
-    }
-  };
-  visit(rootDirectory);
-  return files;
-}

--- a/scripts/vsix.mjs
+++ b/scripts/vsix.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Reads a packaged VSIX back out of the archive.
+//
+// Both the packaging check and the Marketplace publish need to know what a
+// package actually contains, and neither can trust the working tree to answer:
+// a release job re-stamps the version between packaging and publishing, and the
+// publish job downloads the archive as an artifact rather than building it. The
+// archive is the only thing that ships, so it is the only thing worth reading.
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+
+// A VSIX is a zip. Windows runners have no unzip, so they go through the shell
+// that is always present instead of taking a dependency to read our own output.
+export function extractVsix(source, destination) {
+	if (process.platform === "win32") {
+		const archive = join(destination, "mobile-canvas-vsix.zip");
+		copyFileSync(source, archive);
+		try {
+			execFileSync(
+				"powershell.exe",
+				[
+					"-NoLogo",
+					"-NoProfile",
+					"-NonInteractive",
+					"-Command",
+					"Expand-Archive -LiteralPath $env:MC_VSIX -DestinationPath $env:MC_DEST -Force",
+				],
+				{
+					env: { ...process.env, MC_VSIX: archive, MC_DEST: destination },
+					stdio: "inherit",
+				},
+			);
+		} finally {
+			rmSync(archive, { force: true });
+		}
+		return;
+	}
+
+	execFileSync("unzip", ["-q", source, "-d", destination]);
+}
+
+export function withVsix(vsix, callback) {
+	const extracted = mkdtempSync(join(tmpdir(), "mobile-canvas-vsix-"));
+	try {
+		extractVsix(vsix, extracted);
+		return callback(extracted);
+	} finally {
+		rmSync(extracted, { recursive: true, force: true });
+	}
+}
+
+export function listFiles(rootDirectory) {
+	const files = [];
+	const visit = (directory) => {
+		for (const entry of readdirSync(directory, { withFileTypes: true })) {
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				visit(path);
+			} else if (entry.isFile()) {
+				files.push(relative(rootDirectory, path).split(sep).join("/"));
+			}
+		}
+	};
+	visit(rootDirectory);
+	return files;
+}
+
+// The Marketplace serves a package carrying no TargetPlatform to every platform
+// that has no specific package, so a missing attribute is a meaningful value --
+// "this is the fallback" -- rather than absent data, and is reported as null
+// instead of being dropped.
+export function readVsixIdentity(directory) {
+	const manifest = readFileSync(join(directory, "extension.vsixmanifest"), "utf8");
+	const identity = /<Identity\b[^>]*>/.exec(manifest);
+	if (!identity) {
+		throw new Error("VSIX manifest has no <Identity> element");
+	}
+
+	const target = /\bTargetPlatform="([^"]+)"/.exec(identity[0]);
+	const extensionPackage = JSON.parse(
+		readFileSync(join(directory, "extension", "package.json"), "utf8"),
+	);
+
+	return {
+		id: `${extensionPackage.publisher}.${extensionPackage.name}`,
+		version: extensionPackage.version,
+		target: target ? target[1] : null,
+		package: extensionPackage,
+	};
+}
+
+// vsce refuses to publish an extension carrying user-provided SVG images, and
+// it refuses at publish time -- long after packaging succeeded and a tag went
+// out. Checking it here fails the pull request that introduces the image
+// instead of the release that tries to ship it.
+//
+// The rule is narrower than "no SVGs in the package": it covers the manifest
+// icon, manifest badges, and images in the readme. It does not cover contributed
+// icons, which is why media/activitybar.svg stays an SVG -- the activity bar
+// tints that mark with currentColor, so a raster copy would be wrong in half of
+// the themes.
+//
+// vsce rewrites relative readme links against the repository field when it
+// packages, so by the time an image reaches the VSIX it should already be
+// absolute. One that is not would be broken on the Marketplace page.
+export function verifyPublishableImages(extensionPackage, readme) {
+  const reject = (where, source) => {
+    if (source.toLowerCase().split("?")[0].endsWith(".svg")) {
+      throw new Error(
+        `${where} may not be an SVG; vsce refuses to publish it: ${source}`,
+      );
+    }
+  };
+
+  reject("the marketplace icon", extensionPackage.icon ?? "");
+  for (const badge of extensionPackage.badges ?? []) {
+    reject("a marketplace badge", badge.url ?? "");
+  }
+
+  const sources = [
+    ...readme.matchAll(/!\[[^\]]*\]\(\s*<?([^)>\s]+)/g),
+    ...readme.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi),
+  ].map((match) => match[1]);
+
+  for (const source of sources) {
+    reject("a readme image", source);
+    if (!/^https:\/\//i.test(source)) {
+      throw new Error(
+        `readme images must resolve to https URLs for the marketplace: ${source}`,
+      );
+    }
+  }
+}

--- a/tests/scripts/marketplace-images.test.mjs
+++ b/tests/scripts/marketplace-images.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { verifyPublishableImages } from "../../scripts/vsix.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// vsce rejects user-provided SVGs at publish time, which is after packaging
+// succeeded and after the tag went out. These pin the rule to the pull request
+// that would introduce the image instead.
+test("marketplace images reject SVG sources", () => {
+  assert.throws(
+    () => verifyPublishableImages({ icon: "media/icon.svg" }, ""),
+    /marketplace icon may not be an SVG/,
+  );
+  assert.throws(
+    () => verifyPublishableImages(
+      { icon: "media/icon.png", badges: [{ url: "https://example.com/b.svg" }] },
+      "",
+    ),
+    /badge may not be an SVG/,
+  );
+  assert.throws(
+    () => verifyPublishableImages(
+      { icon: "media/icon.png" },
+      "![shot](https://example.com/shot.svg)",
+    ),
+    /readme image may not be an SVG/,
+  );
+  assert.throws(
+    () => verifyPublishableImages(
+      { icon: "media/icon.png" },
+      '<img src="https://example.com/shot.SVG?v=2">',
+    ),
+    /readme image may not be an SVG/,
+  );
+});
+
+// vsce rewrites relative readme links to absolute URLs when it packages, so a
+// relative path surviving into the VSIX is a link that would be broken on the
+// marketplace page.
+test("marketplace readme images must be absolute https URLs", () => {
+  assert.throws(
+    () => verifyPublishableImages({ icon: "media/icon.png" }, "![shot](media/shot.png)"),
+    /must resolve to https/,
+  );
+  assert.throws(
+    () => verifyPublishableImages(
+      { icon: "media/icon.png" },
+      "![shot](http://example.com/shot.png)",
+    ),
+    /must resolve to https/,
+  );
+  verifyPublishableImages(
+    { icon: "media/icon.png" },
+    "![shot](https://example.com/shot.png)\n<img src='https://example.com/b.png'>",
+  );
+});
+
+// The rule covers the manifest icon, badges, and readme images. It does not
+// cover contributed icons, so the activity bar mark stays an SVG: the activity
+// bar tints it with currentColor, and a raster copy would be wrong in half the
+// themes.
+test("the shipped extension satisfies the marketplace image rules", () => {
+  const extensionPackage = JSON.parse(
+    readFileSync(join(root, "vscode", "package.json"), "utf8"),
+  );
+  const readme = readFileSync(join(root, "vscode", "README.md"), "utf8");
+
+  verifyPublishableImages(extensionPackage, readme);
+
+  assert.equal(
+    extensionPackage.contributes.viewsContainers.activitybar[0].icon,
+    "media/activitybar.svg",
+  );
+});

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -133,10 +133,10 @@
   "scripts": {
     "compile": "tsc -p .",
     "check:web": "node --check ../web/canvas-state.js && node --check ../web/device-canvas.js && node --check media/vscode-theme.js && node --check media/vscode-transport.js",
-    "check:scripts": "node --check ../lib/runtime.mjs && node --check ../lib/runtime-assets.mjs && node --check ../lib/mcp-vscode-proxy.mjs && node --check ../scripts/mcp-vscode.mjs && node --check ../scripts/prepare-vscode.mjs && node --check ../scripts/prepare-plugin.mjs && node --check ../scripts/package-runtime-assets.mjs && node --check ../scripts/package-vscode-thin.mjs && node --check ../scripts/package-vscode-targets.mjs && node --check ../scripts/smoke-runtime.mjs && node --check ../scripts/verify-vsix.mjs",
+    "check:scripts": "node --check ../lib/runtime.mjs && node --check ../lib/runtime-assets.mjs && node --check ../lib/mcp-vscode-proxy.mjs && node --check ../scripts/mcp-vscode.mjs && node --check ../scripts/prepare-vscode.mjs && node --check ../scripts/prepare-plugin.mjs && node --check ../scripts/package-runtime-assets.mjs && node --check ../scripts/package-vscode-thin.mjs && node --check ../scripts/package-vscode-targets.mjs && node --check ../scripts/smoke-runtime.mjs && node --check ../scripts/vsix.mjs && node --check ../scripts/verify-vsix.mjs && node --check ../scripts/publish-vscode.mjs",
     "prepare-assets": "node ../scripts/prepare-vscode.mjs",
     "build": "npm run compile && npm run check:web && npm run check:scripts && npm run prepare-assets",
-    "test:unit": "node --test test/*.test.mjs ../tests/web/*.test.mjs",
+    "test:unit": "node --test test/*.test.mjs ../tests/web/*.test.mjs ../tests/scripts/*.test.mjs",
     "test:integration": "node out/test/runTest.js",
     "test": "npm run build && npm run test:unit && npm run test:integration",
     "vscode:prepublish": "npm run compile && npm run check:web && npm run check:scripts",


### PR DESCRIPTION
The release workflow already built every VSIX flavour and attached them to the GitHub Release, but reaching Marketplace users was still a manual `vsce` run from someone's laptop. This adds a gated `publish-vscode` job to `.github/workflows/release.yml`.

## What gets published

The six target packages plus the **thin** universal VSIX. The Marketplace serves each target package to the platform it matches and falls back to the untargeted package for everything else, so the thin one covers `linux-armhf`, Alpine, and web.

The bundled universal VSIX stays a GitHub Release download: a version may carry only one untargeted package, and 73 MiB containing five unusable runtimes is a worse default than a first-use fetch.

## Design notes

- **The archive is the source of truth.** A dispatched run can stamp a version the publish job's checkout never saw, so `scripts/publish-vscode.mjs` reads id/version/target out of each VSIX rather than the working tree, and asserts they all agree with the release tag.
- **Re-runs are safe.** The script asks `vsce show` which version+target pairs already exist and publishes only the remainder — which is also how a partially failed publish recovers. `vsce show` prints `undefined` (exit 0) for a never-published extension, so that is parsed defensively.
- **Prereleases are skipped.** The Marketplace accepts only `major.minor.patch`; semver prerelease tags are rejected. A `v*-rc.*` run now says so up front instead of failing mid-upload.
- **No interactive hang.** `vsce` prompts for a token it cannot read, which on a runner is a job that hangs until timeout, so the script fails fast when `VSCE_PAT` is unset.
- Publishes what the release built by downloading the `mobile-canvas-vscode` artifact, rather than rebuilding — a rebuild could differ from the VSIXs users can already download.

## SVG images

vsce refuses to publish user-provided SVGs, but not until publish — after the tag has gone out. `verify-vsix.mjs` now enforces that at packaging time.

The rule covers only the manifest icon, badges, and readme images. It does **not** cover contributed icons, so `media/activitybar.svg` correctly stays an SVG: the activity bar tints it with `currentColor`, and a raster copy would be wrong in half the themes. **No rasterization needed.**

## Setup required before this can run

One secret, `VSCE_PAT`, in a new `vscode-marketplace` environment — an Azure DevOps PAT with **Organization: All accessible organizations** and **Scopes: Marketplace → Manage**. The environment (rather than a repo secret) also allows a required reviewer on the publish without gating the rest of the release.

## Validation

- Built all seven VSIXs locally; `verify-vsix.mjs` passes on each.
- `publish-vscode.mjs --dry-run` selects exactly the six targets + thin fallback.
- Version-mismatch, prerelease-version, and missing-`VSCE_PAT` guards all confirmed to fire.
- 43 unit tests pass, including 3 new ones pinning the Marketplace image rules.