### PR TITLE
Prepare 0.1.12 release

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "mobile-canvas",
       "description": "View, create, boot, and interact with local iOS simulators and Android emulators in a Copilot canvas.",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "author": {
         "name": "Jonathan Dick",
         "url": "https://github.com/Redth"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-canvas",
   "description": "View, create, boot, and interact with local iOS simulators and Android emulators in a Copilot canvas.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "author": {
     "name": "Jonathan Dick",
     "url": "https://github.com/Redth"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.1.11</VersionPrefix>
+    <VersionPrefix>0.1.12</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-canvas",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "View, create, boot, and interact with local iOS simulators and Android emulators from a GitHub Copilot canvas.",
   "main": "extension.mjs",
   "type": "module",

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile-canvas",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile-canvas",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.3"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "mobile-canvas",
   "displayName": "Mobile Canvas",
   "description": "View and interact with local iOS Simulators and Android emulators from VS Code and Copilot Chat.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "publisher": "redth",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
Stamps 0.1.12 across every file that carries a version, so the `v0.1.12` tag passes the release workflow's tag/version check.

This is the first release that will publish the VS Code extension to the Marketplace. The identity path is confirmed working end to end — `vsce verify-pat` reports "verification succeeded for the publisher 'redth'" using the federated managed identity, with no PAT involved.