### PR TITLE
Keep the VS Code bridge alive across device switches

### DIFF
--- a/vscode/src/hostBridge.ts
+++ b/vscode/src/hostBridge.ts
@@ -42,6 +42,11 @@ export interface SelectedDeviceContext {
 
 export class HostBridge implements vscode.Disposable {
   private readonly sockets = new Map<string, WebSocket>();
+  // Sockets we tore down on purpose. `ws` aborts a still-connecting handshake by emitting
+  // `error` before `close`, and switching devices closes the previous video socket while it
+  // is usually still connecting. Without this set our own teardown is indistinguishable from
+  // the host going away, so it would invalidate the connection every device switch.
+  private readonly discarded = new WeakSet<WebSocket>();
   private connection: HostConnection | undefined;
   private connectPromise: Promise<HostConnection> | undefined;
   private disposed = false;
@@ -367,6 +372,13 @@ export class HostBridge implements vscode.Disposable {
     if (channel !== "video" && channel !== "events") {
       throw new Error(`Unsupported Mobile Canvas socket channel: ${String(channel)}`);
     }
+    // The connection can be retired while we await it. Its cookie is already dead, so
+    // opening against it would only earn a 401 handshake failure that then invalidates
+    // whatever connection replaced it. Report the close and let the canvas reopen.
+    if (this.connection !== connection) {
+      void this.post({ type: "socket-closed", id, code: 1006, reason: "" });
+      return;
+    }
     this.closeSocket(id);
     const url = this.apiUrl(`/ws/${channel}`, connection);
     url.search = query ?? "";
@@ -391,6 +403,11 @@ export class HostBridge implements vscode.Disposable {
       void this.post({ type: "socket-message", id, data: payload });
     });
     socket.on("error", (error) => {
+      // A socket we retired reports the aborted handshake as an error. That is our doing,
+      // not a failed connection, and the canvas already moved on from it.
+      if (this.discarded.has(socket)) {
+        return;
+      }
       if (!opened) {
         this.invalidateConnection(connection);
       }
@@ -415,13 +432,20 @@ export class HostBridge implements vscode.Disposable {
     if (!socket) {
       return;
     }
-    socket.terminate();
+    this.discard(socket);
   }
 
   private closeSockets(): void {
     for (const socket of this.sockets.values()) {
-      socket.terminate();
+      this.discard(socket);
     }
+  }
+
+  // The map entry stays until `close` fires so the canvas still receives `socket-closed`
+  // and can settle its own socket state.
+  private discard(socket: WebSocket): void {
+    this.discarded.add(socket);
+    socket.terminate();
   }
 
   private async save(

--- a/vscode/src/test/suite/index.ts
+++ b/vscode/src/test/suite/index.ts
@@ -356,6 +356,45 @@ if (args[0] === "canvas" && args[1] === "open") {
       assert.equal(payload.detail, undefined);
     }
 
+    // Switching devices closes the previous video socket while it is usually still
+    // connecting. `ws` reports that aborted handshake as an error, which used to be
+    // mistaken for a dead host and tore down every other socket plus the session cookie.
+    const bootstrapsBeforeSwitch = bootstrapBodies.length;
+    await bridge.handleMessage({
+      type: "socket-open",
+      id: "video-switch",
+      channel: "video",
+    });
+    await bridge.handleMessage({ type: "socket-close", id: "video-switch" });
+    await bridge.handleMessage({
+      type: "socket-open",
+      id: "video-next",
+      channel: "video",
+    });
+    const nextFrame = await waitForMessage(
+      messages,
+      (message) => message.type === "socket-message" && message.id === "video-next",
+    );
+    assert.equal(nextFrame.type, "socket-message");
+    assert.equal(
+      bootstrapBodies.length,
+      bootstrapsBeforeSwitch,
+      "closing a connecting socket must not re-open the canvas",
+    );
+    assert.ok(
+      !messages.some(
+        (message) => message.type === "socket-closed" && message.id === "activities",
+      ),
+      "closing a connecting socket must not drop the events socket",
+    );
+    assert.ok(
+      !messages.some(
+        (message) => message.type === "socket-error" && message.id === "video-switch",
+      ),
+      "a socket we closed on purpose must not surface as an error",
+    );
+    await bridge.handleMessage({ type: "socket-close", id: "video-next" });
+
     await bridge.setVisible(false);
     assert.ok(messages.some(
       (message) => message.type === "visibility" && !message.visible,


### PR DESCRIPTION
Switching devices away from an iOS simulator and back left the VS Code panel unable to reconnect until the canvas was reopened. This fixes the root cause in the extension host bridge.

## Why

`selectDevice()` calls `stopStream()`, which closes the previous video socket. That socket is usually still handshaking at that moment. `ws` aborts a connecting handshake by emitting `error` **before** `close`, which I confirmed directly:

```
readyState before terminate: 0 (CONNECTING=0)
events: [ 'error:WebSocket was closed before the connection was established', 'close:1006' ]
```

`HostBridge` treated any pre-open error as a dead host:

```ts
socket.on("error", (error) => {
  if (!opened) this.invalidateConnection(connection);  // our own teardown
```

`invalidateConnection()` calls `closeSockets()` and clears the session cookie, so our own deliberate teardown took down the events socket and the video socket that had just been opened for the newly selected device. The forced re-bootstrap then made it worse: `CanvasBootstrapStore.Create()` wipes every session for the key, so the previous cookie was invalidated too.

## Approach

Distinguish a deliberate teardown from a genuine connection failure.

- A `discarded` WeakSet marks sockets we terminate on purpose. Their aborted-handshake error no longer invalidates the shared connection and is not reported to the canvas as an error.
- Map entries are left in place until `close` actually fires, so the webview still receives `socket-closed` and can settle its own socket state.
- `openSocket()` now skips binding to a connection that was retired while `connect()` was awaited. That cookie is already dead, so it would only earn a 401 that invalidates whatever connection replaced it.

## Scope and risk

Changes are confined to `vscode/src/hostBridge.ts`, so this is VS Code only. `web/` is untouched and the GitHub App canvas is unaffected by construction. The browser canvas has no equivalent bug because its sockets talk to the host directly, with no shared connection to invalidate.

## Verification

A regression test in `verifyHostBridge` closes a still-connecting video socket, then immediately opens a replacement, and asserts the replacement receives frames, the events socket survives, and no re-bootstrap happened. Isolating the guard shows the test genuinely catches the bug:

| Run | Fails at |
| --- | --- |
| Baseline, no changes | pre-existing `mobileCanvas.open` view timeout |
| New test, fix removed | the new reconnect assertion |
| New test, fix applied | back to the pre-existing timeout |

Two pre-existing failures show up locally and are not caused by this change: the `mobileCanvas.open` view timeout above (also fails on a clean baseline), and `prepared-assets.test.mjs`, which needs `npm run prepare-assets` because `dist/` is not built. Unit tests are otherwise 42/43 and `tsc` is clean.