### PR TITLE
Fix VS Code iOS stream reconnects

### DIFF
--- a/vscode/src/hostBridge.ts
+++ b/vscode/src/hostBridge.ts
@@ -42,6 +42,8 @@ export interface SelectedDeviceContext {
 
 export class HostBridge implements vscode.Disposable {
   private readonly sockets = new Map<string, WebSocket>();
+  private readonly openingSockets = new Set<string>();
+  private readonly cancelledSockets = new Set<string>();
   // Sockets we tore down on purpose. `ws` aborts a still-connecting handshake by emitting
   // `error` before `close`, and switching devices closes the previous video socket while it
   // is usually still connecting. Without this set our own teardown is indistinguishable from
@@ -101,7 +103,10 @@ export class HostBridge implements vscode.Disposable {
       }
     } catch (error) {
       const text = errorMessage(error);
-      if ("id" in message) {
+      if (message.type === "socket-open") {
+        await this.post({ type: "socket-error", id: message.id, message: text });
+        await this.post({ type: "socket-closed", id: message.id, code: 1006, reason: "" });
+      } else if ("id" in message) {
         await this.post({ type: "operation-error", id: message.id, message: text });
       } else {
         await this.post({ type: "fatal", message: text });
@@ -368,74 +373,90 @@ export class HostBridge implements vscode.Disposable {
     channel: SocketChannel,
     query?: string,
   ): Promise<void> {
-    const connection = await this.connect();
     if (channel !== "video" && channel !== "events") {
       throw new Error(`Unsupported Mobile Canvas socket channel: ${String(channel)}`);
     }
-    // The connection can be retired while we await it. Its cookie is already dead, so
-    // opening against it would only earn a 401 handshake failure that then invalidates
-    // whatever connection replaced it. Report the close and let the canvas reopen.
-    if (this.connection !== connection) {
-      void this.post({ type: "socket-closed", id, code: 1006, reason: "" });
-      return;
-    }
-    this.closeSocket(id);
-    const url = this.apiUrl(`/ws/${channel}`, connection);
-    url.search = query ?? "";
-    url.protocol = "ws:";
-    const socket = new WebSocket(url, { headers: { Cookie: connection.cookie } });
-    this.sockets.set(id, socket);
-    let opened = false;
+    this.openingSockets.add(id);
+    try {
+      const connection = await this.connect();
+      if (this.cancelledSockets.delete(id)) {
+        await this.post({ type: "socket-closed", id, code: 1000, reason: "" });
+        return;
+      }
+      // The connection can be retired while we await it. Its cookie is already dead, so
+      // opening against it would only earn a 401 handshake failure that then invalidates
+      // whatever connection replaced it. Report the close and let the canvas reopen.
+      if (this.connection !== connection) {
+        await this.post({ type: "socket-closed", id, code: 1006, reason: "" });
+        return;
+      }
+      this.closeSocket(id);
+      const url = this.apiUrl(`/ws/${channel}`, connection);
+      url.search = query ?? "";
+      url.protocol = "ws:";
+      const socket = new WebSocket(url, { headers: { Cookie: connection.cookie } });
+      this.sockets.set(id, socket);
+      let opened = false;
 
-    socket.on("open", () => {
-      opened = true;
-      void this.post({ type: "socket-opened", id });
-    });
-    socket.on("message", (data, isBinary) => {
-      if (
-        channel === "events"
-        && (
-          isBinary
-          || !isEventForCanvas(data.toString(), this.sessionId, this.instanceId)
-        )
-      ) return;
-      const payload = isBinary ? toArrayBuffer(data) : data.toString();
-      void this.post({ type: "socket-message", id, data: payload });
-    });
-    socket.on("error", (error) => {
-      // A socket we retired reports the aborted handshake as an error. That is our doing,
-      // not a failed connection, and the canvas already moved on from it.
-      if (this.discarded.has(socket)) {
-        return;
-      }
-      if (!opened) {
-        this.invalidateConnection(connection);
-      }
-      void this.post({ type: "socket-error", id, message: error.message });
-    });
-    socket.on("close", (code, reason) => {
-      if (this.sockets.get(id) !== socket) {
-        return;
-      }
-      this.sockets.delete(id);
-      void this.post({
-        type: "socket-closed",
-        id,
-        code,
-        reason: reason.toString(),
+      socket.on("open", () => {
+        opened = true;
+        void this.post({ type: "socket-opened", id });
       });
-    });
+      socket.on("message", (data, isBinary) => {
+        if (
+          channel === "events"
+          && (
+            isBinary
+            || !isEventForCanvas(data.toString(), this.sessionId, this.instanceId)
+          )
+        ) return;
+        const payload = isBinary ? toArrayBuffer(data) : data.toString();
+        void this.post({ type: "socket-message", id, data: payload });
+      });
+      socket.on("error", (error) => {
+        // A socket we retired reports the aborted handshake as an error. That is our doing,
+        // not a failed connection, and the canvas already moved on from it.
+        if (this.discarded.has(socket)) {
+          return;
+        }
+        if (!opened) {
+          this.invalidateConnection(connection);
+        }
+        void this.post({ type: "socket-error", id, message: error.message });
+      });
+      socket.on("close", (code, reason) => {
+        if (this.sockets.get(id) !== socket) {
+          return;
+        }
+        this.sockets.delete(id);
+        void this.post({
+          type: "socket-closed",
+          id,
+          code,
+          reason: reason.toString(),
+        });
+      });
+    } finally {
+      this.openingSockets.delete(id);
+      this.cancelledSockets.delete(id);
+    }
   }
 
   private closeSocket(id: string): void {
     const socket = this.sockets.get(id);
     if (!socket) {
+      if (this.openingSockets.has(id)) {
+        this.cancelledSockets.add(id);
+      }
       return;
     }
     this.discard(socket);
   }
 
   private closeSockets(): void {
+    for (const id of this.openingSockets) {
+      this.cancelledSockets.add(id);
+    }
     for (const socket of this.sockets.values()) {
       this.discard(socket);
     }

--- a/vscode/src/test/suite/index.ts
+++ b/vscode/src/test/suite/index.ts
@@ -356,16 +356,22 @@ if (args[0] === "canvas" && args[1] === "open") {
       assert.equal(payload.detail, undefined);
     }
 
-    // Switching devices closes the previous video socket while it is usually still
-    // connecting. `ws` reports that aborted handshake as an error, which used to be
-    // mistaken for a dead host and tore down every other socket plus the session cookie.
+    // VS Code dispatches webview messages without awaiting the previous one. Switching devices can
+    // therefore close the previous video socket while the bridge is still awaiting its connection.
+    // The pending open must be cancelled before it creates an abandoned native video stream.
     const bootstrapsBeforeSwitch = bootstrapBodies.length;
-    await bridge.handleMessage({
+    const abandonedOpen = bridge.handleMessage({
       type: "socket-open",
       id: "video-switch",
       channel: "video",
     });
     await bridge.handleMessage({ type: "socket-close", id: "video-switch" });
+    await abandonedOpen;
+    const abandonedClose = await waitForMessage(
+      messages,
+      (message) => message.type === "socket-closed" && message.id === "video-switch",
+    );
+    assert.equal(abandonedClose.type, "socket-closed");
     await bridge.handleMessage({
       type: "socket-open",
       id: "video-next",
@@ -389,9 +395,11 @@ if (args[0] === "canvas" && args[1] === "open") {
     );
     assert.ok(
       !messages.some(
-        (message) => message.type === "socket-error" && message.id === "video-switch",
+        (message) =>
+          (message.type === "socket-opened" || message.type === "socket-message")
+          && message.id === "video-switch",
       ),
-      "a socket we closed on purpose must not surface as an error",
+      "a socket closed while awaiting the host must never be opened",
     );
     await bridge.handleMessage({ type: "socket-close", id: "video-next" });
 
@@ -433,6 +441,31 @@ if (args[0] === "canvas" && args[1] === "open") {
     assert.deepEqual(readJsonPart(uiToolResult.content[1]), {
       root: { role: "button", label: "Continue" },
     });
+
+    const failedMessages: ExtensionMessage[] = [];
+    const failedBridge = new HostBridge(
+      join(directory, "missing-mobile-canvas"),
+      "failed-session",
+      "failed-view",
+      {
+        postMessage: async (message) => {
+          failedMessages.push(message);
+          return true;
+        },
+      },
+      { appendLine: () => {} },
+    );
+    try {
+      await failedBridge.handleMessage({
+        type: "socket-open",
+        id: "failed-video",
+        channel: "video",
+      });
+      assert.equal(failedMessages[0]?.type, "socket-error");
+      assert.equal(failedMessages[1]?.type, "socket-closed");
+    } finally {
+      failedBridge.dispose();
+    }
   } finally {
     bridge.dispose();
     delete process.env.MOBILE_CANVAS_COMMAND;


### PR DESCRIPTION
## Summary

VS Code can lose a video socket close while the host bridge is still awaiting its connection. Repeated simulator stop/start or view lifecycle changes can then leave abandoned native streams behind and the iOS view stuck connecting.

- Track pending socket opens and cancel them before creating the WebSocket.
- Cancel pending opens when the view hides, disposes, or invalidates its host connection.
- Surface pre-open failures as socket error/close events so the webview can recover instead of hanging.
- Cover concurrent webview message dispatch and host startup failure paths.

## Testing

- `npm test --prefix vscode`
- `npm run package --prefix vscode`