### PR TITLE
Add .claude-plugin manifests so Claude Code can install the plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "name": "mobile-canvas-ghcp",
+  "metadata": {
+    "description": "Live iOS and Android device control for developers and Copilot agents.",
+    "version": "1.0.0"
+  },
+  "owner": {
+    "name": "Jonathan Dick",
+    "url": "https://github.com/Redth"
+  },
+  "plugins": [
+    {
+      "name": "mobile-canvas",
+      "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
+      "version": "0.1.13",
+      "author": {
+        "name": "Jonathan Dick",
+        "url": "https://github.com/Redth"
+      },
+      "repository": "https://github.com/Redth/mobile-canvas-ghcp",
+      "license": "MIT",
+      "keywords": [
+        "ios",
+        "android",
+        "simulator",
+        "emulator",
+        "copilot-canvas",
+        "canvas",
+        "mobile",
+        "device-control",
+        "mobile-testing",
+        "device-automation",
+        "mcp"
+      ],
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "mobile-canvas",
       "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "author": {
         "name": "Jonathan Dick",
         "url": "https://github.com/Redth"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "mobile-canvas",
+  "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
+  "version": "0.1.13",
+  "author": {
+    "name": "Jonathan Dick",
+    "url": "https://github.com/Redth"
+  },
+  "repository": "https://github.com/Redth/mobile-canvas-ghcp",
+  "license": "MIT",
+  "keywords": [
+    "ios",
+    "android",
+    "simulator",
+    "emulator",
+    "copilot-canvas",
+    "canvas",
+    "mobile",
+    "device-control",
+    "mobile-testing",
+    "device-automation",
+    "mcp"
+  ],
+  "logo": "assets/preview.png",
+  "extensions": "extensions",
+  "mcpServers": "./.mcp.json"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-canvas",
   "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "author": {
     "name": "Jonathan Dick",
     "url": "https://github.com/Redth"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,8 @@ jobs:
             Directory.Build.props
             .github/plugin/plugin.json
             .github/plugin/marketplace.json
+            .claude-plugin/plugin.json
+            .claude-plugin/marketplace.json
 
   publish-vscode:
     name: VS Code Marketplace

--- a/scripts/prepare-plugin.mjs
+++ b/scripts/prepare-plugin.mjs
@@ -21,6 +21,7 @@ rmSync(output, { recursive: true, force: true });
 mkdirSync(output, { recursive: true });
 
 for (const relative of [
+  ".claude-plugin",
   ".github/plugin",
   ".mcp.json",
   "assets",

--- a/scripts/stamp-version.mjs
+++ b/scripts/stamp-version.mjs
@@ -3,8 +3,9 @@
 // silently: package.json is the plugin version, vscode/package*.json describe
 // the VS Code package,
 // Directory.Build.props is what the binary reports from `mobile-canvas
-// --version`, and the two files under .github/plugin are what someone browsing
-// the marketplace sees. Drift means a bug report names a version that never
+// --version`, and the manifests under .github/plugin (Copilot) and
+// .claude-plugin (Claude Code) are what someone browsing a marketplace sees.
+// Drift means a bug report names a version that never
 // shipped -- which had already happened, with the marketplace manifests left a
 // whole release behind at 0.1.0 while the binary shipped 0.1.1.
 //
@@ -98,6 +99,8 @@ const files = [
 	},
 	jsonFile(".github/plugin/plugin.json", (document) => document),
 	jsonFile(".github/plugin/marketplace.json", marketplacePlugin),
+	jsonFile(".claude-plugin/plugin.json", (document) => document),
+	jsonFile(".claude-plugin/marketplace.json", marketplacePlugin),
 	{
 		relative: "Directory.Build.props",
 		read: () => {


### PR DESCRIPTION
`/plugin marketplace add Redth/mobile-canvas-ghcp` currently fails in Claude Code:

```
✘ Failed to add marketplace: Marketplace file not found at
  .../Redth-mobile-canvas-ghcp/.claude-plugin/marketplace.json
```

The repo already ships everything Claude Code needs — `.mcp.json` even uses
`${CLAUDE_PLUGIN_ROOT}` — but Claude Code only discovers marketplaces at
`.claude-plugin/marketplace.json`, and the manifests live under
`.github/plugin/` for the Copilot app. This adds the second location.

### Changes

- `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json` — copies of the
  `.github/plugin/` pair. One field differs: `plugins[0].source` is `"./"` rather
  than `"."`, because Claude Code's schema rejects a bare `.` (`plugins.0.source:
  Invalid input`) and requires path sources to start with `./`. The `.github/plugin/`
  manifests are untouched.
- `scripts/stamp-version.mjs` — stamps the two new files, so they can't drift.
  This is the failure mode the header comment already describes, so adding
  unstamped copies seemed worse than not adding them at all. `marketplacePlugin`
  is reused, so `metadata.version` stays put and only `plugins[]` moves.
- `scripts/prepare-plugin.mjs` — copies `.claude-plugin` into the packaged plugin.

### Verified

`stamp-version.mjs --check` sees all 8 files and agrees on 0.1.13; stamping 0.1.14
moves both new manifests and leaves `metadata.version` at 1.0.0.

With this branch applied, on Ubuntu 22.04:

```
✔ Successfully added marketplace: mobile-canvas-ghcp
✔ Successfully installed plugin: mobile-canvas@mobile-canvas-ghcp
```

The MCP server then starts and fails on that host for an unrelated reason — the
`linux-x64` binary needs `GLIBC_2.38` and 22.04 has 2.35. Not touched here, but
happy to file it separately if it's news.

I have not tested the Copilot or VS Code packaging paths beyond the script changes
above — worth a look before merging.
