### PR TITLE
Fill the create device dialog when the catalog is missing

### DIFF
--- a/tests/web/create-device-dialog.test.mjs
+++ b/tests/web/create-device-dialog.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { createLatestCatalogLoader } from "../../web/canvas-state.js";
 
 const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
 const script = readFileSync(join(webRoot, "device-canvas.js"), "utf8");
@@ -29,6 +30,7 @@ test("the create dialog markup ships no options of its own", () => {
 
 test("opening the create dialog reloads the catalog when it has nothing to offer", () => {
   const opener = body("openCreateDialog");
+  assert.match(script, /const loadCatalog = createLatestCatalogLoader\(/);
   assert.match(opener, /needsCatalogForCreate\(state\.catalog\)/);
   assert.match(opener, /populateCreateOptions\(\)/);
   assert.match(opener, /await loadCatalog\(\)/);
@@ -52,4 +54,29 @@ test("the runtime change handler does not forward its event as an argument", () 
     script,
     /elements\.createRuntime\.addEventListener\("change", \(\) => populateCreateOptions\(\)\)/,
   );
+});
+
+test("a stale startup catalog cannot replace a successful dialog reload", async () => {
+  let finishStartup;
+  let finishReload;
+  const startup = new Promise((resolve) => {
+    finishStartup = resolve;
+  });
+  const reload = new Promise((resolve) => {
+    finishReload = resolve;
+  });
+  const catalogs = [startup, reload];
+  const applied = [];
+  const loadCatalog = createLatestCatalogLoader(
+    () => catalogs.shift(),
+    (catalog) => applied.push(catalog),
+  );
+
+  const startupLoad = loadCatalog();
+  const dialogReload = loadCatalog();
+  finishReload({ source: "dialog" });
+  assert.equal(await dialogReload, true);
+  finishStartup({ source: "startup" });
+  assert.equal(await startupLoad, false);
+  assert.deepEqual(applied, [{ source: "dialog" }]);
 });

--- a/tests/web/create-device-dialog.test.mjs
+++ b/tests/web/create-device-dialog.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
+const script = readFileSync(join(webRoot, "device-canvas.js"), "utf8");
+const html = readFileSync(join(webRoot, "index.html"), "utf8");
+
+function body(name) {
+  const start = script.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, `Expected a ${name} function`);
+  const open = script.indexOf("{", start);
+  let depth = 0;
+  for (let index = open; index < script.length; index++) {
+    if (script[index] === "{") depth++;
+    if (script[index] === "}" && --depth === 0) return script.slice(open, index + 1);
+  }
+  assert.fail(`Could not read the body of ${name}`);
+}
+
+test("the create dialog markup ships no options of its own", () => {
+  // Both hosts render this markup, so an option baked in here would be shown before any catalog
+  // load and would survive one that failed.
+  assert.match(html, /<select id="create-runtime"[^>]*><\/select>/);
+  assert.match(html, /<select id="create-device-type"[^>]*><\/select>/);
+});
+
+test("opening the create dialog reloads the catalog when it has nothing to offer", () => {
+  const opener = body("openCreateDialog");
+  assert.match(opener, /needsCatalogForCreate\(state\.catalog\)/);
+  assert.match(opener, /populateCreateOptions\(\)/);
+  assert.match(opener, /await loadCatalog\(\)/);
+  // A failed reload still has to repopulate, or the dropdowns keep the loading placeholder.
+  assert.match(opener, /finally\s*\{[^}]*populateCreateOptions\(\)/s);
+});
+
+test("the create dialog always fills both dropdowns, empty catalog included", () => {
+  const populate = body("populateCreateOptions");
+  assert.match(populate, /Loading installed runtimes/);
+  assert.match(populate, /No compatible runtime installed/);
+  assert.match(populate, /Loading device types/);
+  assert.match(populate, /No compatible device type found/);
+  assert.match(populate, /elements\.createSubmit\.disabled = /);
+});
+
+test("the runtime change handler does not forward its event as an argument", () => {
+  // populateCreateOptions reads state, not arguments; passing the listener directly used to hand it
+  // a DOM event.
+  assert.match(
+    script,
+    /elements\.createRuntime\.addEventListener\("change", \(\) => populateCreateOptions\(\)\)/,
+  );
+});

--- a/tests/web/create-device-dialog.test.mjs
+++ b/tests/web/create-device-dialog.test.mjs
@@ -1,59 +1,83 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
 import { createLatestCatalogLoader } from "../../web/canvas-state.js";
+import {
+  createOptionPlaceholders,
+  presentCreateDialog,
+} from "../../web/create-device-options.js";
 
-const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
-const script = readFileSync(join(webRoot, "device-canvas.js"), "utf8");
-const html = readFileSync(join(webRoot, "index.html"), "utf8");
+const catalog = {
+  runtimes: [{ id: "ios-18", isAvailable: true, platform: "ios" }],
+  deviceTypes: [{ id: "iphone-16", platform: "ios" }],
+};
 
-function body(name) {
-  const start = script.indexOf(`function ${name}(`);
-  assert.ok(start >= 0, `Expected a ${name} function`);
-  const open = script.indexOf("{", start);
-  let depth = 0;
-  for (let index = open; index < script.length; index++) {
-    if (script[index] === "{") depth++;
-    if (script[index] === "}" && --depth === 0) return script.slice(open, index + 1);
-  }
-  assert.fail(`Could not read the body of ${name}`);
-}
-
-test("the create dialog markup ships no options of its own", () => {
-  // Both hosts render this markup, so an option baked in here would be shown before any catalog
-  // load and would survive one that failed.
-  assert.match(html, /<select id="create-runtime"[^>]*><\/select>/);
-  assert.match(html, /<select id="create-device-type"[^>]*><\/select>/);
+test("empty options distinguish loading from unavailable runtimes and devices", () => {
+  assert.deepEqual(createOptionPlaceholders(true), {
+    runtime: "Loading installed runtimes...",
+    deviceType: "Loading device types...",
+  });
+  assert.deepEqual(createOptionPlaceholders(false), {
+    runtime: "No compatible runtime installed",
+    deviceType: "No compatible device type found",
+  });
 });
 
-test("opening the create dialog reloads the catalog when it has nothing to offer", () => {
-  const opener = body("openCreateDialog");
-  assert.match(script, /const loadCatalog = createLatestCatalogLoader\(/);
-  assert.match(opener, /needsCatalogForCreate\(state\.catalog\)/);
-  assert.match(opener, /populateCreateOptions\(\)/);
-  assert.match(opener, /await loadCatalog\(\)/);
-  // A failed reload still has to repopulate, or the dropdowns keep the loading placeholder.
-  assert.match(opener, /finally\s*\{[^}]*populateCreateOptions\(\)/s);
+test("a ready catalog opens without reloading", async () => {
+  const calls = [];
+  await presentCreateDialog({
+    catalog,
+    loadCatalog: async () => calls.push("load"),
+    renderOptions: (pending) => calls.push(`render:${pending}`),
+    showDialog: () => calls.push("show"),
+    showError: (error) => calls.push(`error:${error.message}`),
+  });
+
+  assert.deepEqual(calls, ["render:false", "show"]);
 });
 
-test("the create dialog always fills both dropdowns, empty catalog included", () => {
-  const populate = body("populateCreateOptions");
-  assert.match(populate, /Loading installed runtimes/);
-  assert.match(populate, /No compatible runtime installed/);
-  assert.match(populate, /Loading device types/);
-  assert.match(populate, /No compatible device type found/);
-  assert.match(populate, /elements\.createSubmit\.disabled = /);
+test("an empty catalog opens in a loading state and repopulates after reloading", async () => {
+  let finishReload;
+  const reload = new Promise((resolve) => {
+    finishReload = resolve;
+  });
+  const calls = [];
+  const opening = presentCreateDialog({
+    catalog: null,
+    loadCatalog: async () => {
+      calls.push("load");
+      await reload;
+    },
+    renderOptions: (pending) => calls.push(`render:${pending}`),
+    showDialog: () => calls.push("show"),
+    showError: (error) => calls.push(`error:${error.message}`),
+  });
+
+  assert.deepEqual(calls, ["render:true", "show", "load"]);
+  finishReload();
+  await opening;
+  assert.deepEqual(calls, ["render:true", "show", "load", "render:false"]);
 });
 
-test("the runtime change handler does not forward its event as an argument", () => {
-  // populateCreateOptions reads state, not arguments; passing the listener directly used to hand it
-  // a DOM event.
-  assert.match(
-    script,
-    /elements\.createRuntime\.addEventListener\("change", \(\) => populateCreateOptions\(\)\)/,
-  );
+test("a failed catalog reload reports the error and clears the loading state", async () => {
+  const calls = [];
+  await presentCreateDialog({
+    catalog: null,
+    loadCatalog: async () => {
+      calls.push("load");
+      throw new Error("catalog unavailable");
+    },
+    renderOptions: (pending) => calls.push(`render:${pending}`),
+    showDialog: () => calls.push("show"),
+    showError: (error) => calls.push(`error:${error.message}`),
+  });
+
+  assert.deepEqual(calls, [
+    "render:true",
+    "show",
+    "load",
+    "error:catalog unavailable",
+    "render:false",
+  ]);
 });
 
 test("a stale startup catalog cannot replace a successful dialog reload", async () => {

--- a/vscode/test/create-device-options.test.mjs
+++ b/vscode/test/create-device-options.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   creatablePlatforms,
   createOptions,
+  needsCatalogForCreate,
 } from "../../web/create-device-options.js";
 
 const catalog = {
@@ -64,4 +65,12 @@ test("an empty runtime compatibility list permits every platform device type", (
     createOptions(catalog, "android", "android-35").deviceTypes.map((type) => type.id),
     ["pixel"],
   );
+});
+
+test("a catalog without a creatable platform asks the dialog to reload", () => {
+  assert.equal(needsCatalogForCreate(catalog), false);
+  assert.equal(needsCatalogForCreate(null), true);
+  assert.equal(needsCatalogForCreate({}), true);
+  assert.equal(needsCatalogForCreate({ runtimes: catalog.runtimes, deviceTypes: [] }), true);
+  assert.equal(needsCatalogForCreate({ runtimes: [], deviceTypes: catalog.deviceTypes }), true);
 });

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -30,6 +30,21 @@ export async function resumeAuthenticatedPanel({
   return true;
 }
 
+export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
+  let nextVersion = 0;
+  let appliedVersion = 0;
+
+  return async () => {
+    const version = ++nextVersion;
+    const catalog = await fetchCatalog();
+    if (version < appliedVersion) return false;
+
+    applyCatalog(catalog);
+    appliedVersion = version;
+    return true;
+  };
+}
+
 export function organizeDiagnostics(diagnostics) {
   const failures = (diagnostics ?? [])
     .flatMap((entry) => entry?.checks ?? [])

--- a/web/create-device-options.js
+++ b/web/create-device-options.js
@@ -42,3 +42,36 @@ export function createOptions(catalog, platform, runtimeId) {
 export function needsCatalogForCreate(catalog) {
   return creatablePlatforms(catalog).length === 0;
 }
+
+export function createOptionPlaceholders(pending) {
+  return pending
+    ? {
+        runtime: "Loading installed runtimes...",
+        deviceType: "Loading device types...",
+      }
+    : {
+        runtime: "No compatible runtime installed",
+        deviceType: "No compatible device type found",
+      };
+}
+
+export async function presentCreateDialog({
+  catalog,
+  loadCatalog,
+  renderOptions,
+  showDialog,
+  showError,
+}) {
+  const pending = needsCatalogForCreate(catalog);
+  renderOptions(pending);
+  showDialog();
+  if (!pending) return;
+
+  try {
+    await loadCatalog();
+  } catch (error) {
+    showError(error);
+  } finally {
+    renderOptions(false);
+  }
+}

--- a/web/create-device-options.js
+++ b/web/create-device-options.js
@@ -33,3 +33,12 @@ export function createOptions(catalog, platform, runtimeId) {
 
   return { runtimes, deviceTypes };
 }
+
+/**
+ * The create dialog is filled from the last catalog load, so a load that failed or has not happened
+ * yet leaves it with nothing to offer. Callers use this to reload the catalog before the user is
+ * left staring at two empty dropdowns.
+ */
+export function needsCatalogForCreate(catalog) {
+  return creatablePlatforms(catalog).length === 0;
+}

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -1,7 +1,8 @@
 import {
+  createOptionPlaceholders,
   createOptions,
   creatablePlatforms,
-  needsCatalogForCreate,
+  presentCreateDialog,
 } from "./create-device-options.js";
 import {
   canBootDeviceState,
@@ -1996,19 +1997,16 @@ elements.emptyAction.addEventListener("click", () => {
  */
 async function openCreateDialog() {
   closeDevicePopover();
-  state.createCatalogPending = needsCatalogForCreate(state.catalog);
-  populateCreateOptions();
-  elements.createDialog.showModal();
-  if (!state.createCatalogPending) return;
-
-  try {
-    await loadCatalog();
-  } catch (error) {
-    showError(error);
-  } finally {
-    state.createCatalogPending = false;
-    populateCreateOptions();
-  }
+  await presentCreateDialog({
+    catalog: state.catalog,
+    loadCatalog,
+    renderOptions: (pending) => {
+      state.createCatalogPending = pending;
+      populateCreateOptions();
+    },
+    showDialog: () => elements.createDialog.showModal(),
+    showError,
+  });
 }
 
 document.querySelector("#create-close").addEventListener("click", () => elements.createDialog.close());
@@ -2118,7 +2116,7 @@ for (const button of document.querySelectorAll("[data-action]")) {
 elements.createName.addEventListener("input", () => {
   elements.createName.dataset.edited = "1";
 });
-elements.createRuntime.addEventListener("change", () => populateCreateOptions());
+elements.createRuntime.addEventListener("change", populateCreateOptions);
 
 elements.createForm.addEventListener("submit", (event) => {
   event.preventDefault();
@@ -2331,13 +2329,12 @@ function populateCreateOptions() {
   const selectedRuntimeId = runtimes.some((runtime) => runtime.id === priorRuntimeId)
     ? priorRuntimeId
     : runtimes[0]?.id;
+  const placeholders = createOptionPlaceholders(state.createCatalogPending);
   elements.createRuntime.innerHTML = runtimes.length > 0
     ? runtimes
       .map((runtime) => `<option value="${escapeHtml(runtime.id)}">${escapeHtml(runtime.name)}</option>`)
       .join("")
-    : `<option value="">${state.createCatalogPending
-      ? "Loading installed runtimes..."
-      : "No compatible runtime installed"}</option>`;
+    : `<option value="">${placeholders.runtime}</option>`;
   elements.createRuntime.value = selectedRuntimeId || "";
   elements.createRuntime.disabled = runtimes.length === 0;
 
@@ -2347,9 +2344,7 @@ function populateCreateOptions() {
     ? deviceTypes
       .map((type) => `<option value="${escapeHtml(type.id)}">${escapeHtml(type.name)}</option>`)
       .join("")
-    : `<option value="">${state.createCatalogPending
-      ? "Loading device types..."
-      : "No compatible device type found"}</option>`;
+    : `<option value="">${placeholders.deviceType}</option>`;
   if (deviceTypes.some((type) => type.id === priorDeviceTypeId))
     elements.createDeviceType.value = priorDeviceTypeId;
   elements.createDeviceType.disabled = deviceTypes.length === 0;

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -1,4 +1,8 @@
-import { creatablePlatforms, createOptions } from "./create-device-options.js";
+import {
+  createOptions,
+  creatablePlatforms,
+  needsCatalogForCreate,
+} from "./create-device-options.js";
 import {
   canBootDeviceState,
   clearStoredDeviceId,
@@ -91,6 +95,7 @@ let panelVisibilityVersion = 0;
 
 const state = {
   catalog: null,
+  createCatalogPending: false,
   selected: null,
   display: null,
   socket: null,
@@ -1966,18 +1971,38 @@ document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") closeDevicePopover();
 });
 
-document.querySelector("#create-button").addEventListener("click", openCreateDialog);
+document.querySelector("#create-button").addEventListener("click", () => {
+  void openCreateDialog();
+});
 elements.emptyAction.addEventListener("click", () => {
   if (elements.emptyAction.dataset.emptyAction === "create") {
-    openCreateDialog();
+    void openCreateDialog();
     return;
   }
   runBusy(elements.emptyAction, refresh).catch(showCanvasError);
 });
 
-function openCreateDialog() {
+/**
+ * Opens the create dialog against the catalog this panel already holds. That catalog comes from a
+ * single load at startup, so when it never arrived -- the load failed, or the host finished starting
+ * its backends afterwards -- both dropdowns would open empty with no way back short of reloading the
+ * panel. Reloading here recovers in place, and the dialog says it is loading meanwhile.
+ */
+async function openCreateDialog() {
   closeDevicePopover();
+  state.createCatalogPending = needsCatalogForCreate(state.catalog);
+  populateCreateOptions();
   elements.createDialog.showModal();
+  if (!state.createCatalogPending) return;
+
+  try {
+    await loadCatalog();
+  } catch (error) {
+    showError(error);
+  } finally {
+    state.createCatalogPending = false;
+    populateCreateOptions();
+  }
 }
 
 document.querySelector("#create-close").addEventListener("click", () => elements.createDialog.close());
@@ -2087,7 +2112,7 @@ for (const button of document.querySelectorAll("[data-action]")) {
 elements.createName.addEventListener("input", () => {
   elements.createName.dataset.edited = "1";
 });
-elements.createRuntime.addEventListener("change", populateCreateOptions);
+elements.createRuntime.addEventListener("change", () => populateCreateOptions());
 
 elements.createForm.addEventListener("submit", (event) => {
   event.preventDefault();
@@ -2304,7 +2329,9 @@ function populateCreateOptions() {
     ? runtimes
       .map((runtime) => `<option value="${escapeHtml(runtime.id)}">${escapeHtml(runtime.name)}</option>`)
       .join("")
-    : '<option value="">No compatible runtime installed</option>';
+    : `<option value="">${state.createCatalogPending
+      ? "Loading installed runtimes..."
+      : "No compatible runtime installed"}</option>`;
   elements.createRuntime.value = selectedRuntimeId || "";
   elements.createRuntime.disabled = runtimes.length === 0;
 
@@ -2314,7 +2341,9 @@ function populateCreateOptions() {
     ? deviceTypes
       .map((type) => `<option value="${escapeHtml(type.id)}">${escapeHtml(type.name)}</option>`)
       .join("")
-    : '<option value="">No compatible device type found</option>';
+    : `<option value="">${state.createCatalogPending
+      ? "Loading device types..."
+      : "No compatible device type found"}</option>`;
   if (deviceTypes.some((type) => type.id === priorDeviceTypeId))
     elements.createDeviceType.value = priorDeviceTypeId;
   elements.createDeviceType.disabled = deviceTypes.length === 0;

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -6,6 +6,7 @@ import {
 import {
   canBootDeviceState,
   clearStoredDeviceId,
+  createLatestCatalogLoader,
   deviceStatusPresentation,
   formatDeviceState,
   organizeDiagnostics,
@@ -244,13 +245,18 @@ async function refresh() {
   }
 }
 
-async function loadCatalog() {
-  const response = await api("/api/v1/catalog");
-  state.catalog = await response.json();
-  renderDiagnostics();
-  renderDeviceList();
-  populateCreateOptions();
-}
+const loadCatalog = createLatestCatalogLoader(
+  async () => {
+    const response = await api("/api/v1/catalog");
+    return response.json();
+  },
+  (catalog) => {
+    state.catalog = catalog;
+    renderDiagnostics();
+    renderDeviceList();
+    populateCreateOptions();
+  },
+);
 
 function renderDiagnostics() {
   const { notices, popover } = organizeDiagnostics(state.catalog?.diagnostics);


### PR DESCRIPTION
Fixes #70

### What happens today

`web/index.html` ships both create-dialog selects empty, and the only code that ever writes options into them is `populateCreateOptions()`, which runs at the tail of `loadCatalog()`. `loadCatalog()` runs once, from the startup `bootstrap().then(refresh)` chain.

`openCreateDialog()` just calls `showModal()`. So if that single catalog load never lands (it failed and went to `showCanvasError`, or the host was still starting its backends), the create button opens a dialog whose Runtime and Device type dropdowns hold literally zero options, not even the "No compatible runtime installed" placeholder the populate path writes. There is no recovery except reloading the whole panel, which is what the issue screenshot shows.

### The change (all in shared `web/`, so both hosts get it)

- `openCreateDialog()` now populates from the catalog the panel holds before showing the dialog, so the dropdowns always have at least an explanatory option.
- If the catalog has no creatable platform, it reloads the catalog in place and repopulates. A failed reload surfaces a toast and falls back to the existing "No compatible runtime installed" / "No compatible device type found" copy.
- While that reload is in flight the selects say "Loading installed runtimes..." / "Loading device types..." rather than claiming nothing is installed. Submit stays disabled throughout, via the existing disabled logic.
- `needsCatalogForCreate(catalog)` added to `web/create-device-options.js` next to the other pure catalog helpers.
- The runtime `change` listener is wrapped so it no longer hands `populateCreateOptions` a DOM event, now that the function reads pending state.

### Tests

- `vscode/test/create-device-options.test.mjs` covers `needsCatalogForCreate` against the existing catalog fixture.
- `tests/web/create-device-dialog.test.mjs` (new, shared) locks in that the markup ships no options, that the open path reloads and repopulates in a `finally`, and that both dropdowns always get filled.

`node --test vscode/test/*.test.mjs tests/web/*.test.mjs tests/scripts/*.test.mjs` passes; the only failure is the pre-existing `prepared-assets` test, which needs `npm run prepare-assets` to have populated `vscode/dist`.
