### PR TITLE
Keep the device view's webview context while it is hidden

### DIFF
--- a/tests/web/frame-lifecycle.test.mjs
+++ b/tests/web/frame-lifecycle.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createFramePrimer,
+  shouldRetainDeviceFrame,
+} from "../../web/canvas-state.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function closableFrame() {
+  return {
+    closed: false,
+    close() {
+      this.closed = true;
+    },
+  };
+}
+
+test("retains a painted frame only when reconnecting the same device", () => {
+  assert.equal(shouldRetainDeviceFrame("ios:phone", "ios:phone"), true);
+  assert.equal(shouldRetainDeviceFrame("ios:phone", "android:pixel"), false);
+  assert.equal(shouldRetainDeviceFrame(null, "ios:phone"), false);
+  assert.equal(shouldRetainDeviceFrame(null, null), false);
+});
+
+test("primes an empty device frame from a screenshot", async () => {
+  const calls = [];
+  const frame = closableFrame();
+  const primer = createFramePrimer({
+    capture: async (deviceId) => {
+      calls.push(["capture", deviceId]);
+      return "screenshot";
+    },
+    decode: async (source) => {
+      calls.push(["decode", source]);
+      return frame;
+    },
+    isCurrent: (deviceId) => deviceId === "ios:phone",
+  });
+
+  const painted = await primer.prime("ios:phone", (value) => {
+    calls.push(["paint", value]);
+  });
+
+  assert.equal(painted, true);
+  assert.deepEqual(calls, [
+    ["capture", "ios:phone"],
+    ["decode", "screenshot"],
+    ["paint", frame],
+  ]);
+  assert.equal(frame.closed, true);
+});
+
+test("does not decode a screenshot after the selected device changes", async () => {
+  const screenshot = deferred();
+  let selectedDeviceId = "ios:phone";
+  let decoded = false;
+  let painted = false;
+  const primer = createFramePrimer({
+    capture: () => screenshot.promise,
+    decode: async () => {
+      decoded = true;
+      return closableFrame();
+    },
+    isCurrent: (deviceId) => deviceId === selectedDeviceId,
+  });
+
+  const result = primer.prime("ios:phone", () => {
+    painted = true;
+  });
+  selectedDeviceId = "android:pixel";
+  screenshot.resolve("stale screenshot");
+
+  assert.equal(await result, false);
+  assert.equal(decoded, false);
+  assert.equal(painted, false);
+});
+
+test("discards a decoded screenshot when the panel becomes hidden", async () => {
+  const decoding = deferred();
+  const decodeStarted = deferred();
+  const frame = closableFrame();
+  let visible = true;
+  let painted = false;
+  const primer = createFramePrimer({
+    capture: async () => "screenshot",
+    decode: () => {
+      decodeStarted.resolve();
+      return decoding.promise;
+    },
+    isCurrent: () => visible,
+  });
+
+  const result = primer.prime("ios:phone", () => {
+    painted = true;
+  });
+  await decodeStarted.promise;
+  visible = false;
+  decoding.resolve(frame);
+
+  assert.equal(await result, false);
+  assert.equal(painted, false);
+  assert.equal(frame.closed, true);
+});
+
+test("discards a screenshot when a live frame arrives first", async () => {
+  const decoding = deferred();
+  const decodeStarted = deferred();
+  const frame = closableFrame();
+  let painted = false;
+  const primer = createFramePrimer({
+    capture: async () => "screenshot",
+    decode: () => {
+      decodeStarted.resolve();
+      return decoding.promise;
+    },
+    isCurrent: () => true,
+  });
+
+  const result = primer.prime("ios:phone", () => {
+    painted = true;
+  });
+  await decodeStarted.promise;
+  primer.invalidate();
+  decoding.resolve(frame);
+
+  assert.equal(await result, false);
+  assert.equal(painted, false);
+  assert.equal(frame.closed, true);
+});

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -20,7 +20,15 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     output,
     viewProvider,
-    vscode.window.registerWebviewViewProvider(VIEW_ID, viewProvider),
+    // The canvas is expensive to rebuild: a hidden view otherwise tears the webview down, and
+    // coming back re-bootstraps the host session, reloads the catalog, and reconnects the video
+    // stream from scratch, which reads as the panel crashing back to its loading state. The page
+    // already stops streaming and drops its sockets while hidden (MobileCanvasViewProvider wires
+    // onDidChangeVisibility to HostBridge.setVisible, and the page acts on it in setPanelVisible),
+    // so retaining the context keeps no capture running.
+    vscode.window.registerWebviewViewProvider(VIEW_ID, viewProvider, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
     vscode.commands.registerCommand("mobileCanvas.open", async () => {
       await vscode.commands.executeCommand("workbench.view.extension.mobileCanvas");
       await vscode.commands.executeCommand(`${VIEW_ID}.focus`);

--- a/vscode/test/view-lifecycle.test.mjs
+++ b/vscode/test/view-lifecycle.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const src = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+const extension = readFileSync(join(src, "extension.ts"), "utf8");
+const viewProvider = readFileSync(join(src, "viewProvider.ts"), "utf8");
+
+test("the device view keeps its webview context while hidden", () => {
+  // Without this the webview is destroyed whenever the view is hidden, so returning to it restarts
+  // the panel cold: a fresh bootstrap, another catalog load, and a reconnecting live stream.
+  assert.match(
+    extension,
+    /registerWebviewViewProvider\(\s*VIEW_ID,\s*viewProvider,\s*\{\s*webviewOptions:\s*\{\s*retainContextWhenHidden:\s*true\s*\}/s,
+  );
+});
+
+test("a hidden view still stops streaming instead of capturing in the background", () => {
+  // Retaining the context is only cheap because visibility is still forwarded, so assert the wiring
+  // that pays for it stays in place.
+  assert.match(
+    viewProvider,
+    /onDidChangeVisibility\(\s*\(\) => void bridge\.setVisible\(webviewView\.visible\)/,
+  );
+});

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -30,6 +30,38 @@ export async function resumeAuthenticatedPanel({
   return true;
 }
 
+export function shouldRetainDeviceFrame(frameDeviceId, selectedDeviceId) {
+  return typeof selectedDeviceId === "string"
+    && selectedDeviceId.length > 0
+    && frameDeviceId === selectedDeviceId;
+}
+
+export function createFramePrimer({ capture, decode, isCurrent }) {
+  let version = 0;
+  const isActive = (requestVersion, deviceId) =>
+    requestVersion === version && isCurrent(deviceId);
+
+  return {
+    invalidate() {
+      version += 1;
+    },
+    async prime(deviceId, paint) {
+      const requestVersion = ++version;
+      const source = await capture(deviceId);
+      if (!isActive(requestVersion, deviceId)) return false;
+
+      const frame = await decode(source);
+      try {
+        if (!isActive(requestVersion, deviceId)) return false;
+        paint(frame);
+        return true;
+      } finally {
+        frame?.close?.();
+      }
+    },
+  };
+}
+
 export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
   let nextVersion = 0;
   let appliedVersion = 0;

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -7,12 +7,14 @@ import {
 import {
   canBootDeviceState,
   clearStoredDeviceId,
+  createFramePrimer,
   createLatestCatalogLoader,
   deviceStatusPresentation,
   formatDeviceState,
   organizeDiagnostics,
   readStoredDeviceId,
   resumeAuthenticatedPanel,
+  shouldRetainDeviceFrame,
   shouldDrainIdleDecoder,
   storeDeviceId,
 } from "./canvas-state.js";
@@ -107,6 +109,7 @@ const state = {
   frameClock: performance.now(),
   parser: null,
   framePainted: false,
+  frameDeviceId: null,
   pointer: null,
   wheel: null,
   wheelTimer: null,
@@ -126,6 +129,18 @@ const state = {
   followTarget: null,
   panelVisible: !document.hidden,
 };
+
+const framePrimer = createFramePrimer({
+  capture: async (deviceId) => {
+    const response = await api(`/api/v1/devices/${encodeURIComponent(deviceId)}/screenshot`);
+    return response.blob();
+  },
+  decode: (blob) => createImageBitmap(blob),
+  isCurrent: (deviceId) =>
+    state.panelVisible
+    && !state.detached
+    && state.selected?.id === deviceId,
+});
 
 async function api(path, options = {}) {
   let response = await sendApiRequest(path, options);
@@ -458,14 +473,15 @@ async function selectDevice(device, persist) {
   }
   if (selectionVersion !== state.selectionVersion) return;
 
+  const retainFrame = shouldRetainDeviceFrame(state.frameDeviceId, device.id);
   state.selected = device;
   storeDeviceId(localStorage, canvasInstanceId(), device.id);
   // A cursor left over from the previous device would point at coordinates that no longer mean
   // anything, so drop the overlay whenever the selection changes.
   endAutomation();
-  // The canvas keeps its last painted frame, so without this the previous device's screen shows
-  // through under the "Starting live view..." overlay as though it belonged to the new one.
-  clearScreen();
+  // Reusing the selected device is a refresh/reconnect, so keep its last frame visible. A genuinely
+  // different selection must not inherit pixels from the previous device.
+  if (!retainFrame) clearScreen();
   elements.empty.classList.add("hidden");
   elements.detached.classList.add("hidden");
   elements.view.classList.remove("hidden");
@@ -526,6 +542,7 @@ function showEmptySelection() {
   endAutomation();
   state.selected = null;
   state.display = null;
+  clearScreen();
   elements.view.classList.add("hidden");
   elements.detached.classList.add("hidden");
   configureEmptyState({
@@ -914,7 +931,10 @@ function startStream() {
   stopStream();
   if (!state.panelVisible || !state.selected || state.selected.state !== "booted") return;
 
-  showDeviceStatus("connecting");
+  const deviceId = state.selected.id;
+  const retainFrame = shouldRetainDeviceFrame(state.frameDeviceId, deviceId);
+  if (retainFrame) hideDeviceStatus();
+  else showDeviceStatus("connecting");
   setStreamMode("connecting");
   state.frameClock = performance.now();
 
@@ -975,6 +995,13 @@ function startStream() {
       startPngFallback("PNG");
     }
   });
+  if (!retainFrame) {
+    void primeScreen(deviceId).catch((error) => {
+      if (state.panelVisible && !state.detached && state.selected?.id === deviceId) {
+        console.warn("Could not preload the initial device frame.", error);
+      }
+    });
+  }
 }
 
 function showStreamFailure(error) {
@@ -986,6 +1013,7 @@ function showStreamFailure(error) {
 }
 
 function stopStream() {
+  framePrimer.invalidate();
   // The parser holds a pending flush timer that would otherwise fire into a closed decoder.
   if (state.parser) {
     state.parser.dispose();
@@ -1133,12 +1161,16 @@ class AnnexBDecoder {
 }
 
 function clearScreen() {
+  framePrimer.invalidate();
   elements.canvas.width = 180;
   elements.canvas.height = 400;
   state.canvasContext = null;
+  state.frameDeviceId = null;
 }
 
 function drawVideoFrame(frame) {
+  // A real stream frame wins over an in-flight screenshot used to seed an otherwise empty canvas.
+  framePrimer.invalidate();
   // H.264 codes in 16-pixel macroblocks, so a frame whose real size is not a multiple of 16 carries
   // padding that the visible rectangle excludes. The short drawImage overload leaves that crop up to
   // the implementation, and WebKit blits the padded coded buffer, which showed up as a strip of
@@ -1208,6 +1240,7 @@ function drawScreenSource(source, sourceX, sourceY, sourceWidth, sourceHeight) {
     sourceHeight,
   );
   context.restore();
+  state.frameDeviceId = state.selected?.id ?? null;
 }
 
 // The stream can silently degrade to idb when ScreenCaptureKit is unavailable, which reads as a
@@ -1247,6 +1280,7 @@ function startPngFallback(label) {
     || !state.selected
     || state.selected.state !== "booted"
   ) return;
+  framePrimer.invalidate();
   applyCaptureSource({ source: "png", sourceDetail: "Screenshot polling fallback." });
   if (state.socket) {
     const socket = state.socket;
@@ -1262,19 +1296,25 @@ function startPngFallback(label) {
   setStreamMode(label);
   const capture = async () => {
     state.pngTimer = null;
+    const deviceId = state.selected?.id;
+    if (
+      !deviceId
+      || !state.panelVisible
+      || state.detached
+      || state.selected.state !== "booted"
+      || state.socket
+    ) return;
     try {
-      const response = await api(`/api/v1/devices/${encodeURIComponent(state.selected.id)}/screenshot`);
-      const bitmap = await createImageBitmap(await response.blob());
-      drawScreenSource(bitmap, 0, 0, bitmap.width, bitmap.height);
-      bitmap.close();
-      hideDeviceStatus();
-      countFrame();
+      await primeScreen(deviceId, countFrame);
     } catch (error) {
-      showDeviceStatus("disconnected", { detail: error.message });
+      if (state.panelVisible && !state.detached && state.selected?.id === deviceId) {
+        showDeviceStatus("disconnected", { detail: error.message });
+      }
     } finally {
       if (
         state.panelVisible
         && !state.detached
+        && state.selected?.id === deviceId
         && state.selected?.state === "booted"
         && !state.socket
       ) {
@@ -1283,6 +1323,14 @@ function startPngFallback(label) {
     }
   };
   state.pngTimer = setTimeout(capture, 0);
+}
+
+function primeScreen(deviceId, onPaint) {
+  return framePrimer.prime(deviceId, (bitmap) => {
+    drawScreenSource(bitmap, 0, 0, bitmap.width, bitmap.height);
+    hideDeviceStatus();
+    onPaint?.();
+  });
 }
 
 function countFrame() {


### PR DESCRIPTION
Refs #71

### What I found

`vscode/src/extension.ts` registers the view with `vscode.window.registerWebviewViewProvider(VIEW_ID, viewProvider)` and no `webviewOptions`. `retainContextWhenHidden` does not appear anywhere in the repo, so VS Code destroys the webview as soon as the view stops being visible and reloads the document when it comes back.

That throws away everything the panel built up: the bootstrapped host session, the loaded catalog, the selected device, the canvas contents, and the video socket. Coming back to the view therefore paints an empty canvas and drops into the connecting state again, which is what #71 describes as a crash to a black screen followed by #69's loading view.

The rest of the code is already written for a surviving context, which is what makes this look like a missed option rather than a deliberate trade:

- `MobileCanvasViewProvider` forwards `onDidChangeVisibility` to `HostBridge.setVisible`, which closes the proxied sockets when the view hides.
- `setPanelVisible` in `web/device-canvas.js` stops the stream, drops the automation socket, and resumes both through `resumeAuthenticatedPanel` when the panel returns.

None of that resume logic can run if the page is destroyed instead of hidden. Retaining the context also costs no background capture, because those same paths stop the stream while hidden.

### The change

- Register the view with `webviewOptions: { retainContextWhenHidden: true }`.
- `vscode/test/view-lifecycle.test.mjs` asserts the registration retains the context, and that the visibility forwarding that makes it cheap stays wired.

### Verification, and its limits

`npx tsc -p vscode --noEmit` and `node --test vscode/test/*.test.mjs` pass. I could not reproduce #71 end to end: it needs macOS with a booted simulator, and I am on Windows, so this is reasoned from the code rather than confirmed against the reported repro. Happy to adjust if you would rather scope the retention differently.

I also looked at whether this fully explains #69 and I do not think it does. The loading overlay is only dismissed by `hideDeviceStatus()` on the first painted frame, and the capture sources deliberately emit nothing while the screen is static: `CaptureOutput.stream` in `native/mobile-screencap/Sources/Capture.swift` drops every non-`.complete` sample buffer. On a booted but idle simulator there is no first frame to paint, which fits "the loading view only disappears after clicking the Home button". That looks like a separate fix (prime the canvas with a screenshot, or emit one frame on stream start) and I left it out of this PR.
