### PR TITLE
Keep the VS Code live view connected when switching Activity Bar tabs

### DIFF
--- a/tests/web/device-status.test.mjs
+++ b/tests/web/device-status.test.mjs
@@ -62,3 +62,12 @@ test("primary actions retain their semantic fill on hover", () => {
     /background:\s*var\(--success-emphasis\)/,
   );
 });
+
+test("starts on the live view instead of the empty selector", () => {
+  assert.match(html, /id="empty-state" class="empty-state hidden"/);
+  assert.match(html, /id="device-view" class="device-view"/);
+  assert.doesNotMatch(html, /id="device-view" class="device-view hidden"/);
+  assert.match(html, />Opening live view</);
+  assert.match(html, /Connecting to a running simulator or emulator/);
+  assert.match(html, /id="selector-detail"[^>]*>Opening live view</);
+});

--- a/vscode/media/vscode-transport.js
+++ b/vscode/media/vscode-transport.js
@@ -10,6 +10,7 @@
   let refreshHandler = null;
   let automationHandler = null;
   let refreshPending = false;
+  let visibilityPending = null;
   const queuedAutomation = [];
 
   function id() {
@@ -115,7 +116,8 @@
         sockets.get(message.id)?.closed(message.code, message.reason);
         break;
       case "visibility":
-        visibilityHandler?.(message.visible);
+        if (visibilityHandler) visibilityHandler(message.visible);
+        else visibilityPending = message.visible;
         break;
       case "refresh":
         if (refreshHandler) refreshHandler();
@@ -180,6 +182,11 @@
 
     onVisibilityChanged(handler) {
       visibilityHandler = handler;
+      if (visibilityPending !== null) {
+        const visible = visibilityPending;
+        visibilityPending = null;
+        visibilityHandler(visible);
+      }
     },
 
     onRefreshRequested(handler) {

--- a/vscode/src/hostBridge.ts
+++ b/vscode/src/hostBridge.ts
@@ -51,6 +51,7 @@ export class HostBridge implements vscode.Disposable {
   private readonly discarded = new WeakSet<WebSocket>();
   private connection: HostConnection | undefined;
   private connectPromise: Promise<HostConnection> | undefined;
+  private closeTask: Promise<void> | undefined;
   private disposed = false;
   private signalOffset = 0;
   private selectionToRestore: string | undefined;
@@ -116,9 +117,6 @@ export class HostBridge implements vscode.Disposable {
   }
 
   async setVisible(visible: boolean): Promise<void> {
-    if (!visible) {
-      this.closeSockets();
-    }
     await this.post({ type: "visibility", visible });
   }
 
@@ -187,9 +185,13 @@ export class HostBridge implements vscode.Disposable {
       unwatchFile(this.refreshSignal, this.onRefreshSignal);
     }
     this.closeSockets();
-    void this.closeCanvas().catch((error) => {
+    this.closeTask = this.closeCanvas().catch((error) => {
       this.output.appendLine(`Mobile Canvas close failed: ${errorMessage(error)}`);
     });
+  }
+
+  closed(): Promise<void> {
+    return this.closeTask ?? Promise.resolve();
   }
 
   private async connect(): Promise<HostConnection> {

--- a/vscode/src/test/suite/index.ts
+++ b/vscode/src/test/suite/index.ts
@@ -62,7 +62,6 @@ async function verifyActivation(): Promise<void> {
   );
   assert.equal(definition.version, extension.packageJSON.version);
   assert.equal(definition.cwd?.toString(), extension.extensionUri.toString());
-
   const titleTarget: { title?: string; description?: string } = {};
   applyViewTitle(titleTarget, "  Pixel\n6  ", " Android 15  ·  booted ");
   assert.deepEqual(titleTarget, {
@@ -403,10 +402,29 @@ if (args[0] === "canvas" && args[1] === "open") {
     );
     await bridge.handleMessage({ type: "socket-close", id: "video-next" });
 
+    await bridge.handleMessage({
+      type: "socket-open",
+      id: "video-hide",
+      channel: "video",
+    });
+    await waitForMessage(
+      messages,
+      (message) => message.type === "socket-opened" && message.id === "video-hide",
+    );
+    const beforeHide = messages.length;
     await bridge.setVisible(false);
-    assert.ok(messages.some(
-      (message) => message.type === "visibility" && !message.visible,
-    ));
+    await waitFor(() =>
+      messages.slice(beforeHide).some((message) =>
+        message.type === "visibility" && !message.visible
+      )
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.ok(
+      !messages.slice(beforeHide).some((message) =>
+        message.type === "socket-closed" && message.id === "video-hide"
+      ),
+      "hiding the view must keep the live stream so returning does not flash Live view",
+    );
     const bootstrapsBeforeRestart = bootstrapBodies.length;
     await bridge.restart();
     await bridge.handleMessage({ type: "ready" });

--- a/vscode/src/viewProvider.ts
+++ b/vscode/src/viewProvider.ts
@@ -28,6 +28,8 @@ export function applyViewTitle(
 export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   private view: vscode.WebviewView | undefined;
   private bridge: HostBridge | undefined;
+  private resolveGeneration = 0;
+  private closing: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -37,7 +39,13 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   ) {}
 
   async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
-    this.bridge?.dispose();
+    const generation = ++this.resolveGeneration;
+    this.retireBridge();
+    await this.closing;
+    if (generation !== this.resolveGeneration) {
+      return;
+    }
+
     this.view = webviewView;
     webviewView.webview.options = {
       enableScripts: true,
@@ -47,6 +55,10 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
       ],
     };
     const runtime = await resolveMobileCanvas(this.context);
+    if (generation !== this.resolveGeneration) {
+      return;
+    }
+
     this.output.appendLine(`Mobile Canvas runtime: ${runtime.source}`);
     const bridge = new HostBridge(
       runtime.command,
@@ -72,10 +84,9 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
     const disposeSubscription = webviewView.onDidDispose(
       () => {
         if (this.bridge === bridge) {
-          this.bridge = undefined;
           this.view = undefined;
+          this.retireBridge();
         }
-        bridge.dispose();
       },
     );
     this.context.subscriptions.push(
@@ -87,6 +98,7 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
     // Attach the bridge before loading the document so its initial ready
     // message cannot be lost while the runtime is resolving.
     webviewView.webview.html = createWebviewHtml(this.context, webviewView.webview);
+    void bridge.setVisible(webviewView.visible);
   }
 
   async refresh(): Promise<void> {
@@ -117,7 +129,19 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   }
 
   dispose(): void {
-    this.bridge?.dispose();
+    this.resolveGeneration += 1;
+    this.view = undefined;
+    this.retireBridge();
+  }
+
+  private retireBridge(): void {
+    const bridge = this.bridge;
+    if (!bridge) {
+      return;
+    }
+    this.bridge = undefined;
+    bridge.dispose();
+    this.closing = bridge.closed();
   }
 
   private requireBridge(): HostBridge {

--- a/vscode/test/canvas-state.test.mjs
+++ b/vscode/test/canvas-state.test.mjs
@@ -2,13 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   canBootDeviceState,
+  canResumeLiveView,
   clearStoredDeviceId,
   deviceStatusPresentation,
+  emptySelectionPresentation,
   formatDeviceState,
+  initialPanelVisible,
+  isCurrentDevice,
   organizeDiagnostics,
   readStoredDeviceId,
   resumeAuthenticatedPanel,
   shouldDrainIdleDecoder,
+  shouldShowConnectingStatus,
+  startupLiveViewPresentation,
   storeDeviceId,
 } from "../../web/canvas-state.js";
 
@@ -235,4 +241,41 @@ test("keeps unsupported diagnostic actions in the selector", () => {
     popover: [check],
   });
   assert.deepEqual(organizeDiagnostics(null), { notices: [], popover: [] });
+});
+
+test("trusts the host visibility signal instead of the document hidden flag", () => {
+  assert.equal(initialPanelVisible(true, true), true);
+  assert.equal(initialPanelVisible(true, false), true);
+  assert.equal(initialPanelVisible(false, true), false);
+  assert.equal(initialPanelVisible(false, false), true);
+});
+
+test("hides the connecting overlay when a live frame is already on screen", () => {
+  assert.equal(shouldShowConnectingStatus(false), true);
+  assert.equal(shouldShowConnectingStatus(true), false);
+});
+
+test("resumes a booted device that still has display geometry", () => {
+  assert.equal(canResumeLiveView({ state: "booted" }, true), true);
+  assert.equal(canResumeLiveView({ state: "booted" }, false), false);
+  assert.equal(canResumeLiveView({ state: "booting" }, true), false);
+  assert.equal(canResumeLiveView(undefined, true), false);
+});
+
+test("does not reselect the device already on screen", () => {
+  assert.equal(isCurrentDevice({ id: "android:phone" }, "android:phone"), true);
+  assert.equal(isCurrentDevice({ id: "android:phone" }, "ios:phone"), false);
+  assert.equal(isCurrentDevice(undefined, "android:phone"), false);
+});
+
+test("starts live view without asking to select a device", () => {
+  const startup = startupLiveViewPresentation();
+  assert.equal(startup.busy, true);
+  assert.equal(startup.title, "Opening live view");
+  assert.match(startup.detail, /simulator or emulator/);
+  assert.equal(startup.action, undefined);
+
+  const empty = emptySelectionPresentation();
+  assert.equal(empty.title, "Select a device");
+  assert.equal(empty.action.id, "create");
 });

--- a/vscode/test/vscode-transport.test.mjs
+++ b/vscode/test/vscode-transport.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
 
-test("bridges bootstrap, API responses, and socket frames", async () => {
+function loadTransport() {
   const outbound = [];
   const listeners = new Map();
   let nextId = 0;
@@ -45,10 +45,14 @@ test("bridges bootstrap, API responses, and socket frames", async () => {
     "utf8",
   );
   vm.runInNewContext(script, sandbox);
-  const transport = window.mobileCanvasTransport;
   const receive = (data) => {
     for (const listener of listeners.get("message") ?? []) listener({ data });
   };
+  return { outbound, receive, transport: window.mobileCanvasTransport };
+}
+
+test("bridges bootstrap, API responses, and socket frames", async () => {
+  const { outbound, receive, transport } = loadTransport();
 
   const bootstrap = transport.bootstrap();
   assert.equal(outbound.shift().type, "ready");
@@ -144,4 +148,12 @@ test("bridges bootstrap, API responses, and socket frames", async () => {
 
   socket.close();
   assert.equal(outbound.shift().type, "socket-close");
+});
+
+test("replays visibility that arrived before the canvas subscribed", () => {
+  const { receive, transport } = loadTransport();
+  let visible = true;
+  receive({ type: "visibility", visible: false });
+  transport.onVisibilityChanged((value) => { visible = value; });
+  assert.equal(visible, false);
 });

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -77,6 +77,43 @@ export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
   };
 }
 
+export function initialPanelVisible(hostOwnsVisibility, documentHidden = false) {
+  return hostOwnsVisibility ? true : !documentHidden;
+}
+
+export function shouldShowConnectingStatus(hasVisibleFrame) {
+  return hasVisibleFrame !== true;
+}
+
+export function canResumeLiveView(device, hasDisplay) {
+  return device?.state === "booted" && hasDisplay === true;
+}
+
+export function isCurrentDevice(current, nextId) {
+  return Boolean(current?.id) && current.id === nextId;
+}
+
+export function emptySelectionPresentation() {
+  return {
+    tone: "accent",
+    icon: "#icon-device",
+    title: "Select a device",
+    detail: "Choose an existing target, or create one from an installed runtime.",
+    action: { id: "create", label: "New device", icon: "#icon-plus" },
+  };
+}
+
+export function startupLiveViewPresentation() {
+  return {
+    tone: "accent",
+    icon: "#icon-device",
+    eyebrow: "Live view",
+    title: "Opening live view",
+    detail: "Connecting to a running simulator or emulator.",
+    busy: true,
+  };
+}
+
 export function organizeDiagnostics(diagnostics) {
   const failures = (diagnostics ?? [])
     .flatMap((entry) => entry?.checks ?? [])
@@ -155,7 +192,7 @@ export function deviceStatusPresentation(kind, { deviceName, platform, detail } 
         icon: "#icon-device",
         eyebrow: "Live view",
         title: `Connecting to ${subject}`,
-        detail: detail || "Preparing a secure, interactive stream.",
+        detail: detail || "Connecting to a running simulator or emulator.",
         busy: true,
       };
     case "restarting":

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -6,16 +6,21 @@ import {
 } from "./create-device-options.js";
 import {
   canBootDeviceState,
+  canResumeLiveView,
   clearStoredDeviceId,
   createFramePrimer,
   createLatestCatalogLoader,
   deviceStatusPresentation,
+  emptySelectionPresentation,
   formatDeviceState,
+  initialPanelVisible,
+  isCurrentDevice,
   organizeDiagnostics,
   readStoredDeviceId,
   resumeAuthenticatedPanel,
   shouldRetainDeviceFrame,
   shouldDrainIdleDecoder,
+  shouldShowConnectingStatus,
   storeDeviceId,
 } from "./canvas-state.js";
 
@@ -105,6 +110,7 @@ const state = {
   socket: null,
   decoder: null,
   pngTimer: null,
+  streamWatchdog: null,
   frameCounter: 0,
   frameClock: performance.now(),
   parser: null,
@@ -127,7 +133,7 @@ const state = {
   selectionTarget: null,
   selectionVersion: 0,
   followTarget: null,
-  panelVisible: !document.hidden,
+  panelVisible: initialPanelVisible(Boolean(transport?.onVisibilityChanged), document.hidden),
 };
 
 const framePrimer = createFramePrimer({
@@ -545,13 +551,7 @@ function showEmptySelection() {
   clearScreen();
   elements.view.classList.add("hidden");
   elements.detached.classList.add("hidden");
-  configureEmptyState({
-    tone: "accent",
-    icon: "#icon-device",
-    title: "Select a device",
-    detail: "Choose an existing target, or create one from an installed runtime.",
-    action: { id: "create", label: "New device", icon: "#icon-plus" },
-  });
+  configureEmptyState(emptySelectionPresentation());
   elements.empty.classList.remove("hidden");
   setStreamMode("idle");
   setActualFps(0);
@@ -923,6 +923,10 @@ function setText(element, value) {
 }
 
 function hideDeviceStatus() {
+  if (state.streamWatchdog) {
+    clearTimeout(state.streamWatchdog);
+    state.streamWatchdog = null;
+  }
   elements.overlay.classList.add("hidden");
   elements.frame.dataset.status = "streaming";
 }
@@ -934,7 +938,9 @@ function startStream() {
   const deviceId = state.selected.id;
   const retainFrame = shouldRetainDeviceFrame(state.frameDeviceId, deviceId);
   if (retainFrame) hideDeviceStatus();
-  else showDeviceStatus("connecting");
+  else if (shouldShowConnectingStatus(state.framePainted)) {
+    showDeviceStatus("connecting");
+  }
   setStreamMode("connecting");
   state.frameClock = performance.now();
 
@@ -961,6 +967,11 @@ function startStream() {
   socket.binaryType = "arraybuffer";
   const parser = new AnnexBDecoder();
   state.parser = parser;
+  state.streamWatchdog = setTimeout(() => {
+    if (state.socket === socket && !state.framePainted) {
+      startPngFallback("PNG");
+    }
+  }, 4000);
 
   socket.addEventListener("message", (event) => {
     if (state.socket !== socket) return;
@@ -992,6 +1003,10 @@ function startStream() {
   });
   socket.addEventListener("close", () => {
     if (state.socket === socket && !state.pngTimer && !state.detached) {
+      if (!state.panelVisible) {
+        state.socket = null;
+        return;
+      }
       startPngFallback("PNG");
     }
   });
@@ -1032,8 +1047,11 @@ function stopStream() {
     clearTimeout(state.pngTimer);
     state.pngTimer = null;
   }
+  if (state.streamWatchdog) {
+    clearTimeout(state.streamWatchdog);
+    state.streamWatchdog = null;
+  }
   state.frameCounter = 0;
-  state.framePainted = false;
   state.activeScale = null;
   clearTimeout(state.scaleTimer);
   setActualFps(0);
@@ -1166,6 +1184,7 @@ function clearScreen() {
   elements.canvas.height = 400;
   state.canvasContext = null;
   state.frameDeviceId = null;
+  state.framePainted = false;
 }
 
 function drawVideoFrame(frame) {
@@ -1281,6 +1300,10 @@ function startPngFallback(label) {
     || state.selected.state !== "booted"
   ) return;
   framePrimer.invalidate();
+  if (state.streamWatchdog) {
+    clearTimeout(state.streamWatchdog);
+    state.streamWatchdog = null;
+  }
   applyCaptureSource({ source: "png", sourceDetail: "Screenshot polling fallback." });
   if (state.socket) {
     const socket = state.socket;
@@ -1493,6 +1516,7 @@ const automation = {
 function connectAutomationEvents() {
   clearTimeout(automation.retryTimer);
   if (!state.panelVisible || state.detached) return;
+  if (automation.socket) return;
   let socket;
   try {
     socket = createSocket("events");
@@ -1563,7 +1587,7 @@ function addressedToThisCanvas(activity) {
 
 async function followSelection(deviceId) {
   if (!deviceId || state.detached) return;
-  if (state.selectionTarget === deviceId || state.selected?.id === deviceId) return;
+  if (isCurrentDevice(state.selected, deviceId) || state.selectionTarget === deviceId) return;
 
   state.followTarget = deviceId;
   let device = state.catalog?.devices?.find((entry) => entry.id === deviceId);
@@ -1579,10 +1603,17 @@ async function followSelection(deviceId) {
 
 async function reconcileAnnouncedSelection(deviceId, guard = () => true) {
   if (!deviceId || state.detached) return;
+  if (isCurrentDevice(state.selected, deviceId) && canResumeLiveView(state.selected, Boolean(state.display))) {
+    return;
+  }
   state.followTarget = deviceId;
   await loadCatalog();
   if (!guard() || state.followTarget !== deviceId) return;
   const device = state.catalog?.devices?.find((entry) => entry.id === deviceId);
+  if (isCurrentDevice(state.selected, device?.id) && canResumeLiveView(device, Boolean(state.display))) {
+    state.selected = device;
+    return;
+  }
   if (device) {
     await selectDevice(device, false);
   } else {
@@ -2501,12 +2532,13 @@ function setPanelVisible(visible) {
   const visibilityVersion = ++panelVisibilityVersion;
   state.panelVisible = visible;
   if (!visible) {
-    stopStream();
-    clearTimeout(automation.retryTimer);
-    const socket = automation.socket;
-    automation.socket = null;
-    socket?.close();
+    // Keep the live stream. Tearing it down is what flashes "Live view" ~2s after
+    // returning to the Activity Bar, once selection reconcile restarts the socket.
     endAutomation();
+    return;
+  }
+  if (state.socket && canResumeLiveView(state.selected, Boolean(state.display))) {
+    connectAutomationEvents();
     return;
   }
   if (!state.detached) {
@@ -2519,7 +2551,7 @@ function setPanelVisible(visible) {
       isActive,
       // A device can finish booting while its host session is hidden. Re-read its state before
       // deciding whether a stream can start instead of reconnecting from the stale "booting" record.
-      refresh,
+      refresh: resumeVisiblePanel,
       resume: () => {
         connectAutomationEvents();
       },
@@ -2529,8 +2561,24 @@ function setPanelVisible(visible) {
   }
 }
 
-document.addEventListener("visibilitychange", () => setPanelVisible(!document.hidden));
-transport?.onVisibilityChanged?.(setPanelVisible);
+async function resumeVisiblePanel() {
+  if (canResumeLiveView(state.selected, Boolean(state.display))) {
+    await loadCatalog();
+    const updated = state.catalog?.devices?.find((device) => device.id === state.selected.id);
+    if (canResumeLiveView(updated, Boolean(state.display))) {
+      state.selected = updated;
+      startStream();
+      return;
+    }
+  }
+  await refresh();
+}
+
+if (transport?.onVisibilityChanged) {
+  transport.onVisibilityChanged(setPanelVisible);
+} else {
+  document.addEventListener("visibilitychange", () => setPanelVisible(!document.hidden));
+}
 let transportRefresh = Promise.resolve();
 transport?.onRefreshRequested?.(() => {
   if (!state.detached) {

--- a/web/index.html
+++ b/web/index.html
@@ -121,7 +121,7 @@
           </span>
           <span class="selector-copy">
             <span id="selector-name" class="selector-name">Devices</span>
-            <span id="selector-detail" class="selector-detail">No device selected</span>
+            <span id="selector-detail" class="selector-detail">Opening live view</span>
           </span>
           <span id="selector-dot" class="state-dot" aria-hidden="true"></span>
           <svg class="icon selector-chevron" aria-hidden="true"><use href="#icon-chevron-down"></use></svg>
@@ -151,7 +151,7 @@
     ></aside>
 
     <main class="workspace">
-      <section id="empty-state" class="empty-state">
+      <section id="empty-state" class="empty-state hidden">
         <div class="empty-card">
           <div class="empty-icon" aria-hidden="true">
             <svg class="icon"><use id="empty-state-icon" href="#icon-device"></use></svg>
@@ -166,7 +166,7 @@
         </div>
       </section>
 
-      <section id="device-view" class="device-view hidden">
+      <section id="device-view" class="device-view">
         <div class="stage">
           <!--
             The two control clusters float over the stage rather than occupying a toolbar row, so a
@@ -223,9 +223,9 @@
                   </div>
                   <div class="stream-status-copy">
                     <span id="stream-overlay-eyebrow" class="stream-status-eyebrow">Live view</span>
-                    <h2 id="stream-overlay-title" class="stream-status-title">Connecting to device</h2>
+                    <h2 id="stream-overlay-title" class="stream-status-title">Opening live view</h2>
                     <p id="stream-overlay-detail" class="stream-status-detail">
-                      Preparing a secure, interactive stream.
+                      Connecting to a running simulator or emulator.
                     </p>
                   </div>
                   <button id="stream-overlay-action" class="button primary stream-status-action hidden"


### PR DESCRIPTION
## Summary
- Keep the VS Code Activity Bar webview alive when the Mobile icon is clicked or another sidebar is shown, so the live stream is not torn down and recreated on every tab switch.
- Open directly on the live-view connecting state instead of flashing “Select a device”, then keep the last emulator frame instead of showing the Live view overlay again after ~2s.
- Skip same-device selection reconcile on return, and fall back to screenshots if H.264 never produces a first frame.

## Test plan
- [ ] Install/run the VS Code extension, boot an Android emulator, and wait until live view is streaming.
- [ ] Switch to Explorer (or another Activity Bar view) and back to Mobile: the emulator screen should stay up with no “Select a device” or “Live view” overlay flash.
- [ ] Repeat a few times; the stream should remain interactive (tap/home still work).
- [ ] With no device selected, the empty “Select a device” state still appears.
- [ ] `npm test --prefix vscode` (unit + integration).