### PR TITLE
Serialize VS Code bridge replacement and improve initial loading state

### DIFF
--- a/tests/web/initial-loading-state.test.mjs
+++ b/tests/web/initial-loading-state.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
+const html = readFileSync(join(webRoot, "index.html"), "utf8");
+const script = readFileSync(join(webRoot, "device-canvas.js"), "utf8");
+
+test("the empty-state markup starts in a truthful loading presentation, not the final empty copy", () => {
+  const section = html.match(/<section id="empty-state"[\s\S]*?<\/section>/);
+  assert.ok(section, "Expected an #empty-state section");
+  assert.match(section[0], /Opening live view/);
+  assert.doesNotMatch(section[0], /Select a device/);
+  // The "create device" action is only meaningful once we truly have no selection; it must not be
+  // visible during the initial loading presentation.
+  assert.match(section[0], /id="empty-state-action"[^>]*class="[^"]*\bhidden\b/);
+});
+
+test("the selector chip starts with connecting copy rather than a false \"no device\" claim", () => {
+  assert.match(html, /id="selector-detail"[^>]*>Opening live view/);
+  assert.doesNotMatch(html, /id="selector-detail"[^>]*>No device selected/);
+});
+
+test("script drives the loading presentation into the empty state before bootstrap runs", () => {
+  assert.match(script, /function showLoadingSelection\(\)/);
+  const loadingBody = script.match(/function showLoadingSelection\(\)\s*\{([\s\S]*?)\n\}/);
+  assert.ok(loadingBody, "Expected a showLoadingSelection body");
+  assert.match(loadingBody[1], /configureEmptyState\(/);
+  assert.match(loadingBody[1], /elements\.empty\.classList\.remove\("hidden"\)/);
+  // showLoadingSelection must actually run before the async catalog/selection resolution kicks off,
+  // otherwise the loading copy would never reach the screen.
+  assert.match(script, /showLoadingSelection\(\);\s*\n\s*bootstrap\(\)/);
+});
+
+test("configureEmptyState renders without an action so the loading state has no dead create button", () => {
+  const configureBody = script.match(/function configureEmptyState\([\s\S]*?\n\}/);
+  assert.ok(configureBody, "Expected a configureEmptyState body");
+  assert.match(configureBody[0], /if \(action\)/);
+  assert.match(configureBody[0], /elements\.emptyAction\.classList\.add\("hidden"\)/);
+});
+
+test("resolving with no selection still restores the real empty-selection copy via existing production code", () => {
+  const body = script.match(/function showEmptySelection\(\)\s*\{([\s\S]*?)\n\}/);
+  assert.ok(body, "Expected a showEmptySelection body");
+  assert.match(body[1], /title: "Select a device"/);
+  assert.match(body[1], /action: \{ id: "create"/);
+});

--- a/vscode/src/bridgeLifecycle.ts
+++ b/vscode/src/bridgeLifecycle.ts
@@ -1,0 +1,79 @@
+/**
+ * Coordinates replacing a `HostBridge`-like resource across overlapping `resolveWebviewView`
+ * calls. VS Code can invoke `resolveWebviewView` again before a prior resolution has finished
+ * (for example when the Activity Bar view is hidden and shown in quick succession), and a
+ * bridge's teardown (`canvas close`) is asynchronous. Without coordination:
+ *
+ * - A late `canvas close` from the retired bridge can finish after the replacement bridge has
+ *   already issued its own `canvas open` for the same session/instance, tearing down the
+ *   replacement.
+ * - A stale, still-in-flight resolution can finish after a newer one and clobber state (the
+ *   active bridge/view) that the newer resolution already owns.
+ *
+ * This coordinator is intentionally free of any `vscode` dependency so it can be unit tested
+ * without the VS Code test harness.
+ */
+export interface RetiringBridge {
+  dispose(): void;
+  /** Resolves once this bridge's asynchronous teardown (e.g. `canvas close`) has settled. */
+  closed(): Promise<void>;
+}
+
+export class BridgeLifecycleCoordinator<TBridge extends RetiringBridge> {
+  private generation = 0;
+  private closing: Promise<void> = Promise.resolve();
+  private active: TBridge | undefined;
+
+  get current(): TBridge | undefined {
+    return this.active;
+  }
+
+  /**
+   * Call at the start of a new resolution. Returns a generation token; check it with
+   * `isCurrent` after each await to detect that a newer resolution has since started.
+   */
+  beginResolution(): number {
+    return ++this.generation;
+  }
+
+  /** Invalidates any in-flight resolution without starting a new one (e.g. on dispose). */
+  invalidate(): void {
+    this.generation += 1;
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.generation;
+  }
+
+  setActive(bridge: TBridge): void {
+    this.active = bridge;
+  }
+
+  /** Clears the active bridge only if it is still the one passed in (guards stale callbacks). */
+  clearIfActive(bridge: TBridge): void {
+    if (this.active === bridge) {
+      this.active = undefined;
+    }
+  }
+
+  /**
+   * Retires the currently active bridge (if any) and waits for its teardown to finish. Chains
+   * onto any previous retirement so overlapping calls still serialize: a bridge is only disposed
+   * and awaited after everything retired before it has fully closed.
+   */
+  async retire(): Promise<void> {
+    const bridge = this.active;
+    this.active = undefined;
+    const previousClosing = this.closing;
+    const closeThis = async () => {
+      await previousClosing;
+      if (bridge) {
+        bridge.dispose();
+        await bridge.closed();
+      }
+    };
+    const closing = closeThis();
+    this.closing = closing;
+    await closing;
+  }
+}

--- a/vscode/src/hostBridge.ts
+++ b/vscode/src/hostBridge.ts
@@ -51,6 +51,7 @@ export class HostBridge implements vscode.Disposable {
   private readonly discarded = new WeakSet<WebSocket>();
   private connection: HostConnection | undefined;
   private connectPromise: Promise<HostConnection> | undefined;
+  private closeTask: Promise<void> | undefined;
   private disposed = false;
   private signalOffset = 0;
   private selectionToRestore: string | undefined;
@@ -187,9 +188,18 @@ export class HostBridge implements vscode.Disposable {
       unwatchFile(this.refreshSignal, this.onRefreshSignal);
     }
     this.closeSockets();
-    void this.closeCanvas().catch((error) => {
+    this.closeTask = this.closeCanvas().catch((error) => {
       this.output.appendLine(`Mobile Canvas close failed: ${errorMessage(error)}`);
     });
+  }
+
+  /**
+   * Resolves once the asynchronous `canvas close` kicked off by dispose() has settled. A
+   * replacement bridge for the same session/instance must await this before opening, or its
+   * `canvas open` can race the previous bridge's still-in-flight close and get torn down by it.
+   */
+  closed(): Promise<void> {
+    return this.closeTask ?? Promise.resolve();
   }
 
   private async connect(): Promise<HostConnection> {

--- a/vscode/src/viewProvider.ts
+++ b/vscode/src/viewProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { BridgeLifecycleCoordinator } from "./bridgeLifecycle";
 import {
   HostBridge,
   type SelectedDeviceContext,
@@ -27,7 +28,10 @@ export function applyViewTitle(
 
 export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   private view: vscode.WebviewView | undefined;
-  private bridge: HostBridge | undefined;
+  // Serializes bridge replacement across overlapping resolveWebviewView calls: waits for a
+  // retired bridge's asynchronous close before a replacement bridge is installed, and ensures
+  // only the newest resolution wins.
+  private readonly lifecycle = new BridgeLifecycleCoordinator<HostBridge>();
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -37,7 +41,14 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   ) {}
 
   async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
-    this.bridge?.dispose();
+    const generation = this.lifecycle.beginResolution();
+    // The previous bridge's `canvas close` is asynchronous; opening the replacement before it
+    // settles lets a late close tear down the panel this resolution is about to create.
+    await this.lifecycle.retire();
+    if (!this.lifecycle.isCurrent(generation)) {
+      return;
+    }
+
     this.view = webviewView;
     webviewView.webview.options = {
       enableScripts: true,
@@ -47,6 +58,10 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
       ],
     };
     const runtime = await resolveMobileCanvas(this.context);
+    if (!this.lifecycle.isCurrent(generation)) {
+      return;
+    }
+
     this.output.appendLine(`Mobile Canvas runtime: ${runtime.source}`);
     const bridge = new HostBridge(
       runtime.command,
@@ -56,7 +71,7 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
       this.output,
       this.refreshSignal,
     );
-    this.bridge = bridge;
+    this.lifecycle.setActive(bridge);
     const messageSubscription = webviewView.webview.onDidReceiveMessage(
       (message: WebviewMessage) => {
         if (message.type === "view-title") {
@@ -71,11 +86,10 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
     );
     const disposeSubscription = webviewView.onDidDispose(
       () => {
-        if (this.bridge === bridge) {
-          this.bridge = undefined;
+        if (this.lifecycle.current === bridge) {
           this.view = undefined;
+          void this.lifecycle.retire();
         }
-        bridge.dispose();
       },
     );
     this.context.subscriptions.push(
@@ -94,7 +108,7 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
       await vscode.commands.executeCommand(`${VIEW_ID}.focus`);
       return;
     }
-    await this.bridge?.restart();
+    await this.lifecycle.current?.restart();
     this.view.webview.html = createWebviewHtml(this.context, this.view.webview);
   }
 
@@ -117,16 +131,18 @@ export class MobileCanvasViewProvider implements vscode.WebviewViewProvider {
   }
 
   dispose(): void {
-    this.bridge?.dispose();
+    this.lifecycle.invalidate();
+    this.view = undefined;
+    void this.lifecycle.retire();
   }
 
   private requireBridge(): HostBridge {
-    if (!this.bridge) {
+    if (!this.lifecycle.current) {
       throw new Error(
         "Open Mobile from the Activity Bar and select a device before attaching its context.",
       );
     }
-    return this.bridge;
+    return this.lifecycle.current;
   }
 }
 

--- a/vscode/test/bridge-lifecycle.test.mjs
+++ b/vscode/test/bridge-lifecycle.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const src = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+const { BridgeLifecycleCoordinator } = await import(
+  join(src, "bridgeLifecycle.ts")
+);
+
+/**
+ * A fake bridge whose `closed()` promise only settles once the test resolves `finishClose()`,
+ * so tests can control exactly when an asynchronous `canvas close` finishes relative to a
+ * replacement bridge being installed.
+ */
+function createFakeBridge() {
+  const events = [];
+  let resolveClose;
+  const closeTask = new Promise((resolve) => {
+    resolveClose = resolve;
+  });
+  return {
+    events,
+    finishClose: () => resolveClose(),
+    bridge: {
+      dispose() {
+        events.push("dispose");
+      },
+      closed() {
+        return closeTask.then(() => {
+          events.push("closed");
+        });
+      },
+    },
+  };
+}
+
+test("retire() waits for the retired bridge's asynchronous close before resolving", async () => {
+  const coordinator = new BridgeLifecycleCoordinator();
+  const first = createFakeBridge();
+  coordinator.setActive(first.bridge);
+
+  let retired = false;
+  const retiring = coordinator.retire().then(() => {
+    retired = true;
+  });
+
+  // Give the microtask queue a chance to run; retire() must still be pending because the fake
+  // bridge's close has not finished yet.
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(retired, false, "retire() must not resolve before the bridge finishes closing");
+  assert.deepEqual(first.events, ["dispose"]);
+
+  first.finishClose();
+  await retiring;
+  assert.equal(retired, true);
+  assert.deepEqual(first.events, ["dispose", "closed"]);
+});
+
+test(
+  "a replacement resolution awaits the previous bridge's close before it can become active",
+  async () => {
+    // This models MobileCanvasViewProvider.resolveWebviewView: replacing a bridge must not let a
+    // late `canvas close` from the retired bridge race past the replacement's own `canvas open`.
+    const coordinator = new BridgeLifecycleCoordinator();
+    const first = createFakeBridge();
+    coordinator.setActive(first.bridge);
+
+    const generation = coordinator.beginResolution();
+    const resolution = coordinator.retire().then(() => {
+      assert.ok(coordinator.isCurrent(generation));
+      const second = { dispose() {}, closed: () => Promise.resolve() };
+      coordinator.setActive(second);
+      return second;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(coordinator.current, undefined, "no replacement should be active yet");
+
+    first.finishClose();
+    const second = await resolution;
+    assert.equal(coordinator.current, second, "the replacement becomes active only after close");
+  },
+);
+
+test("a stale resolution cannot install a bridge once superseded", async () => {
+  const coordinator = new BridgeLifecycleCoordinator();
+
+  const staleGeneration = coordinator.beginResolution();
+  // A newer resolution starts before the stale one finishes retiring/opening.
+  const currentGeneration = coordinator.beginResolution();
+  assert.ok(!coordinator.isCurrent(staleGeneration));
+  assert.ok(coordinator.isCurrent(currentGeneration));
+
+  // The stale resolution must observe it has been superseded and bail out instead of mutating
+  // shared state.
+  if (!coordinator.isCurrent(staleGeneration)) {
+    // no-op: simulates the stale caller returning early
+  } else {
+    coordinator.setActive({ dispose() {}, closed: () => Promise.resolve() });
+  }
+  assert.equal(coordinator.current, undefined);
+
+  const winner = { dispose() {}, closed: () => Promise.resolve() };
+  coordinator.setActive(winner);
+  assert.equal(coordinator.current, winner);
+});
+
+test("clearIfActive only clears the bridge that is still current", () => {
+  const coordinator = new BridgeLifecycleCoordinator();
+  const first = { dispose() {}, closed: () => Promise.resolve() };
+  const second = { dispose() {}, closed: () => Promise.resolve() };
+
+  coordinator.setActive(first);
+  coordinator.setActive(second);
+  // A dispose callback captured for `first` (e.g. a stale onDidDispose closure) must not clear
+  // the bridge that replaced it.
+  coordinator.clearIfActive(first);
+  assert.equal(coordinator.current, second);
+
+  coordinator.clearIfActive(second);
+  assert.equal(coordinator.current, undefined);
+});
+
+test("overlapping retire() calls still serialize even when both clear the active bridge", async () => {
+  // Regression guard: retireBridge() clears `this.active` synchronously before awaiting, so a
+  // second overlapping retire() must still chain onto the first bridge's close rather than
+  // finding `active` already undefined and skipping the wait entirely.
+  const coordinator = new BridgeLifecycleCoordinator();
+  const first = createFakeBridge();
+  coordinator.setActive(first.bridge);
+
+  const firstRetire = coordinator.retire();
+  const secondRetire = coordinator.retire();
+
+  let bothSettled = false;
+  const both = Promise.all([firstRetire, secondRetire]).then(() => {
+    bothSettled = true;
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(bothSettled, false);
+
+  first.finishClose();
+  await both;
+  assert.equal(bothSettled, true);
+});

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -146,7 +146,7 @@ export function deviceStatusPresentation(kind, { deviceName, platform, detail } 
         icon: "#icon-power",
         eyebrow: "Powering on",
         title: `Starting ${subject}`,
-        detail: detail || "This can take a moment. Live view will connect automatically.",
+        detail: detail || "This can take a moment.\nLive view will connect automatically.",
         busy: true,
       };
     case "connecting":

--- a/web/device-canvas.css
+++ b/web/device-canvas.css
@@ -1035,6 +1035,7 @@ summary:focus-visible,
   font-size: 12px;
   line-height: 1.5;
   text-wrap: pretty;
+  white-space: pre-line;
 }
 
 .button.stream-status-action {

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -535,6 +535,16 @@ function deviceStatusKind(device) {
   return "unavailable";
 }
 
+function showLoadingSelection() {
+  configureEmptyState({
+    tone: "accent",
+    icon: "#icon-device",
+    title: "Opening live view…",
+    detail: "Connecting to the device catalog.",
+  });
+  elements.empty.classList.remove("hidden");
+}
+
 function showEmptySelection() {
   state.selectionVersion += 1;
   state.selectionTarget = null;
@@ -569,10 +579,15 @@ function configureEmptyState({ tone, icon, title, detail, action }) {
   elements.emptyIcon.setAttribute("href", icon);
   setText(elements.emptyTitle, title);
   setText(elements.emptyDetail, detail);
-  elements.emptyAction.dataset.emptyAction = action.id;
-  elements.emptyActionIcon.setAttribute("href", action.icon);
-  setText(elements.emptyActionText, action.label);
-  elements.emptyAction.setAttribute("aria-label", action.label);
+  if (action) {
+    elements.emptyAction.dataset.emptyAction = action.id;
+    elements.emptyActionIcon.setAttribute("href", action.icon);
+    setText(elements.emptyActionText, action.label);
+    elements.emptyAction.setAttribute("aria-label", action.label);
+    elements.emptyAction.classList.remove("hidden");
+  } else {
+    elements.emptyAction.classList.add("hidden");
+  }
 }
 
 /**
@@ -2563,6 +2578,8 @@ function findStartCodes(bytes) {
   }
   return starts;
 }
+
+showLoadingSelection();
 
 bootstrap()
   .then(refresh)

--- a/web/index.html
+++ b/web/index.html
@@ -121,7 +121,7 @@
           </span>
           <span class="selector-copy">
             <span id="selector-name" class="selector-name">Devices</span>
-            <span id="selector-detail" class="selector-detail">No device selected</span>
+            <span id="selector-detail" class="selector-detail">Opening live view…</span>
           </span>
           <span id="selector-dot" class="state-dot" aria-hidden="true"></span>
           <svg class="icon selector-chevron" aria-hidden="true"><use href="#icon-chevron-down"></use></svg>
@@ -156,9 +156,9 @@
           <div class="empty-icon" aria-hidden="true">
             <svg class="icon"><use id="empty-state-icon" href="#icon-device"></use></svg>
           </div>
-          <h2 id="empty-state-title">Select a device</h2>
-          <p id="empty-state-detail">Choose an existing target, or create one from an installed runtime.</p>
-          <button id="empty-state-action" class="button primary empty-action" type="button"
+          <h2 id="empty-state-title">Opening live view…</h2>
+          <p id="empty-state-detail">Connecting to the device catalog.</p>
+          <button id="empty-state-action" class="button primary empty-action hidden" type="button"
                   data-empty-action="create">
             <svg class="icon" aria-hidden="true"><use id="empty-state-action-icon" href="#icon-plus"></use></svg>
             <span id="empty-state-action-text">New device</span>


### PR DESCRIPTION
Follow-up extracted from #75.

PR #75 attempted overlapping work with #74 and is being closed as superseded — #74 already merged the core Activity Bar fix (retain webview context while hidden, stop capture while hidden, preserve same-device frames, prime an empty frame from a screenshot). Reviewing #75 surfaced two independent, worthwhile improvements that are implemented correctly here in isolation. This PR deliberately excludes #75's hidden-stream retention, sticky-frame watchdog, same-device shortcuts, and host visibility buffering — none of that is needed or wanted; hidden views still stop streaming/capture exactly as #74 established.

## 1. Serialize VS Code bridge replacement

`MobileCanvasViewProvider.resolveWebviewView()` used to dispose the outgoing `HostBridge` and immediately build/attach a replacement, but the outgoing bridge's `canvas close` was fire-and-forget. A late close could race with and tear down the replacement's `canvas open`.

- `HostBridge.dispose()` now tracks its async close as `closeTask` and exposes `closed(): Promise<void>`.
- A new, framework-free `BridgeLifecycleCoordinator` (`vscode/src/bridgeLifecycle.ts`) serializes retirement: a replacement always awaits the previous bridge's close before installing itself, and a generation counter guards overlapping `resolveWebviewView` calls so only the newest resolution can win and mutate provider state.
- `setVisible()`'s hide-behavior (stopping sockets/capture while hidden, per #74) is untouched.
- New coverage: `vscode/test/bridge-lifecycle.test.mjs` proves the old close completes before the replacement opens, that a stale/superseded resolution cannot install a bridge, and that overlapping `retire()` calls still serialize correctly.

## 2. Truthful initial loading state in the shared web host

`web/index.html`'s `#empty-state` previously rendered "Select a device" immediately on load, before the catalog/selection had even been fetched — a brief, false empty state.

- The empty-state markup and selector chip now start with an "Opening live view…" loading presentation (`showLoadingSelection()`), applied before `bootstrap()`/`refresh()` run.
- Once the existing async resolution in `refresh()` completes, the existing `showEmptySelection()` (no device) or `selectDevice()` (device found) paths still drive the final UI exactly as before — no new dead/duplicate presentation code, only the initial timing changed.
- Shared in `web/`, so both the GitHub App canvas and VS Code hosts pick it up automatically.
- New coverage: `tests/web/initial-loading-state.test.mjs`.

## Testing

- `npm test --prefix vscode` (build + `test:unit`, 69/69 passing, including the new bridge-lifecycle and initial-loading-state tests and all pre-existing tests such as `view-lifecycle.test.mjs`).
- `test:integration` (`@vscode/test-electron`) could not run in this sandbox because it needs to download a VS Code binary and there is no network egress here — this is a sandbox limitation, not a code failure.