### PR TITLE
Fix IDB companion installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,17 +116,18 @@ and take over at any time.
 
 | | Requirement |
 |---|---|
-| **iOS** | macOS, Xcode with Simulator runtimes, and [`idb_companion`](https://fbidb.io) for input |
+| **iOS** | macOS, Xcode with Simulator runtimes, and [`idb`](https://fbidb.io) (provides `idb_companion`) for input |
 | **Android** | Android SDK with `emulator`, `avdmanager`, and `adb` on `PATH` |
 | **Optional iOS fallback** | Screen Recording and Accessibility permission for ScreenCaptureKit |
 
-For iOS input, install `idb_companion` from its Homebrew tap. Current Homebrew
-versions require explicitly trusting third-party formulae:
+For iOS input, install Meta's `idb` metapackage, which provides
+`idb_companion`. Current Homebrew versions require explicitly trusting the
+third-party tap:
 
 ```bash
 brew tap facebook/fb
-brew trust --formula facebook/fb/idb-companion
-brew install facebook/fb/idb-companion
+brew trust facebook/fb
+brew install facebook/fb/idb
 ```
 
 Then add the installed executable to your shell environment. For zsh:

--- a/tests/web/idb-guidance.test.mjs
+++ b/tests/web/idb-guidance.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatUserFacingMessage,
+  organizeDiagnostics,
+} from "../../web/canvas-state.js";
+
+const expected =
+  "idb_companion was not found. Run "
+  + "`brew tap facebook/fb && brew trust facebook/fb && brew install facebook/fb/idb`, "
+  + "or set MOBILE_CANVAS_IDB_COMPANION or IDB_COMPANION_PATH to the executable.";
+
+test("missing IDB API errors use the current Meta installation", () => {
+  assert.equal(
+    formatUserFacingMessage(
+      "idb_companion was not found. Install it with Homebrew or set "
+      + "MOBILE_CANVAS_IDB_COMPANION.",
+    ),
+    expected,
+  );
+});
+
+test("missing IDB diagnostics use the same actionable guidance", () => {
+  const { popover } = organizeDiagnostics([
+    {
+      checks: [
+        {
+          name: "idb_companion",
+          status: "error",
+          message: "Install idb_companion or set MOBILE_CANVAS_IDB_COMPANION.",
+        },
+      ],
+    },
+  ]);
+
+  assert.equal(popover[0].message, expected);
+});
+
+test("unrelated runtime failures pass through unchanged", () => {
+  const message = "idb_companion exited with code 1";
+  assert.equal(formatUserFacingMessage(message), message);
+});

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -65,8 +65,16 @@ Mobile Canvas or .NET tool to install.
 
 | Platform | What you need |
 |---|---|
-| iOS | macOS, Xcode with Simulator runtimes, and [`idb_companion`](https://fbidb.io) for input |
+| iOS | macOS, Xcode with Simulator runtimes, and [`idb`](https://fbidb.io) (provides `idb_companion`) for input |
 | Android | Android SDK tools and `adb` on `PATH` |
+
+For iOS input, install Meta's current Homebrew package:
+
+```bash
+brew tap facebook/fb
+brew trust facebook/fb
+brew install facebook/fb/idb
+```
 
 VS Code 1.101 or newer is required. Browser-hosted `vscode.dev` is not supported
 because it cannot launch local native runtimes.

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -1,4 +1,18 @@
 const SELECTED_DEVICE_PREFIX = "mobile-canvas-selected-device:";
+const IDB_INSTALL_COMMAND =
+  "brew tap facebook/fb && brew trust facebook/fb && brew install facebook/fb/idb";
+const MISSING_IDB_MESSAGE =
+  `idb_companion was not found. Run \`${IDB_INSTALL_COMMAND}\`, or set `
+  + "MOBILE_CANVAS_IDB_COMPANION or IDB_COMPANION_PATH to the executable.";
+
+export function formatUserFacingMessage(message) {
+  const value = String(message ?? "");
+  const normalized = value.toLowerCase();
+  return normalized.includes("idb_companion was not found")
+      || normalized.includes("install idb_companion")
+    ? MISSING_IDB_MESSAGE
+    : value;
+}
 
 export function readStoredDeviceId(storage, instanceId) {
   const value = storage.getItem(storageKey(instanceId));
@@ -80,7 +94,11 @@ export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
 export function organizeDiagnostics(diagnostics) {
   const failures = (diagnostics ?? [])
     .flatMap((entry) => entry?.checks ?? [])
-    .filter((check) => check?.status !== "ok");
+    .filter((check) => check?.status !== "ok")
+    .map((check) => ({
+      ...check,
+      message: formatUserFacingMessage(check.message),
+    }));
   const notices = [];
   const popover = [];
 

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -11,6 +11,7 @@ import {
   createLatestCatalogLoader,
   deviceStatusPresentation,
   formatDeviceState,
+  formatUserFacingMessage,
   organizeDiagnostics,
   readStoredDeviceId,
   resumeAuthenticatedPanel,
@@ -174,7 +175,9 @@ async function requireSuccessfulResponse(response) {
     const payload = await response.json().catch(() => ({
       message: `${response.status} ${response.statusText}`,
     }));
-    const error = new Error(payload.message || "Mobile Canvas request failed.");
+    const error = new Error(
+      formatUserFacingMessage(payload.message || "Mobile Canvas request failed."),
+    );
     error.code = payload.code;
     error.status = response.status;
     throw error;
@@ -2440,15 +2443,16 @@ function showToast(message, isError = false) {
 }
 
 function showError(error) {
-  showToast(error.message || String(error), true);
+  showToast(formatUserFacingMessage(error.message || String(error)), true);
 }
 
 function showCanvasError(error) {
+  const message = formatUserFacingMessage(error.message || String(error));
   if (state.selected && !state.detached) {
     stopStream();
     showDeviceStatus("error", {
       title: "Couldn't refresh the device",
-      detail: error.message || String(error),
+      detail: message,
       action: { id: "refresh", label: "Refresh devices", icon: "#icon-refresh" },
     });
     setStreamMode("offline");
@@ -2462,7 +2466,7 @@ function showCanvasError(error) {
       tone: "danger",
       icon: "#icon-alert",
       title: "Couldn't load devices",
-      detail: error.message || String(error),
+      detail: message,
       action: { id: "refresh", label: "Try again", icon: "#icon-refresh" },
     });
     elements.empty.classList.remove("hidden");


### PR DESCRIPTION
The released native runtime points users at an outdated Homebrew package when `idb_companion` is missing, leaving iOS input failures without a working recovery path.

## What changed

- Normalize both released missing-IDB error variants in the shared canvas used by the GitHub App and VS Code hosts.
- Direct users to Meta's `facebook/fb/idb` metapackage, including the tap trust step and both supported executable overrides.
- Align both host READMEs and add shared regression coverage while leaving unrelated runtime failures unchanged.

The normalization intentionally lives in the shared web layer so current native runtime assets do not need to be republished. #79 separately tracks making bundled native HID primary and IDB optional.

## Validation

- `npm --prefix vscode test`
- `npm run package:plugin`
- `node scripts/source-hash.mjs --check`
- `git diff --check`

Fixes: #73