### PR TITLE
Keep the simulator live stream alive while the screen is static

### DIFF
--- a/native/mobile-screencap/Sources/Framebuffer.swift
+++ b/native/mobile-screencap/Sources/Framebuffer.swift
@@ -104,12 +104,25 @@ private final class FramebufferCapture: @unchecked Sendable {
 		label: "dev.mobilecanvas.framebuffer.frames",
 		qos: .userInteractive)
 
+	// CoreSimulator only reports damage, so a static screen produces no callbacks at all and the
+	// encoded stream stalls until the user touches something. These drive a keepalive that re-sends
+	// the last frame so the panel keeps painting, and so a client joining an idle device still gets
+	// a decodable keyframe promptly.
+	private let idleTickInterval = 0.2
+	private let idleFrameInterval = 0.4
+	private let idleKeyFrameInterval = 1.0
+
 	private var framebuffer: MCSimulatorFramebuffer?
 	private var currentSurface: IOSurface?
 	private var sourceBuffer: CVPixelBuffer?
 	private var transformer: PixelBufferTransformer?
 	private var encoder: H264Encoder?
+	private var idleTimer: DispatchSourceTimer?
+	// Keepalives re-encode this snapshot rather than re-reading the live IOSurface, which would race
+	// the producer outside the callback boundary that normally guarantees a settled frame.
+	private var lastOutputBuffer: CVPixelBuffer?
 	private var lastEncodedAt = -Double.infinity
+	private var lastKeyFrameAt = -Double.infinity
 	private var didStop = false
 	private var receivedFrames: UInt64 = 0
 	private var droppedFrames: UInt64 = 0
@@ -160,6 +173,7 @@ private final class FramebufferCapture: @unchecked Sendable {
 		do {
 			let ready = try configure(surface)
 			encodeCurrentFrame(force: true)
+			startIdleTimer()
 			lock.unlock()
 			return ready
 		} catch {
@@ -167,6 +181,19 @@ private final class FramebufferCapture: @unchecked Sendable {
 			framebuffer.stop()
 			throw error
 		}
+	}
+
+	private func startIdleTimer() {
+		let timer = DispatchSource.makeTimerSource(queue: frameQueue)
+		timer.schedule(
+			deadline: .now() + idleTickInterval,
+			repeating: idleTickInterval,
+			leeway: .milliseconds(50))
+		timer.setEventHandler { [weak self] in
+			self?.processIdleTick()
+		}
+		idleTimer = timer
+		timer.activate()
 	}
 
 	func stop() {
@@ -178,13 +205,17 @@ private final class FramebufferCapture: @unchecked Sendable {
 		didStop = true
 		let encoder = self.encoder
 		self.encoder = nil
+		let idleTimer = self.idleTimer
+		self.idleTimer = nil
 		transformer = nil
 		sourceBuffer = nil
+		lastOutputBuffer = nil
 		currentSurface = nil
 		let framebuffer = self.framebuffer
 		self.framebuffer = nil
 		lock.unlock()
 
+		idleTimer?.cancel()
 		framebuffer?.stop()
 		encoder?.finish()
 	}
@@ -246,6 +277,25 @@ private final class FramebufferCapture: @unchecked Sendable {
 		}
 	}
 
+	private func processIdleTick() {
+		lock.lock()
+		guard !didStop else {
+			lock.unlock()
+			return
+		}
+		if ProcessInfo.processInfo.systemUptime - lastEncodedAt >= idleFrameInterval {
+			encodeKeepAliveFrame()
+		}
+		// An idle stream never reaches processFrameRendered, so this is the only place a client that
+		// went away while the screen was static is noticed.
+		let disconnected = sink.closed
+		lock.unlock()
+
+		if disconnected {
+			onFailure("client disconnected", false)
+		}
+	}
+
 	private func configure(_ surface: IOSurface) throws -> FramebufferReady {
 		let surfaceReference = unsafeBitCast(surface, to: IOSurfaceRef.self)
 		let sourceWidth = IOSurfaceGetWidth(surfaceReference)
@@ -275,6 +325,9 @@ private final class FramebufferCapture: @unchecked Sendable {
 		sourceBuffer = pixelBuffer
 		if dimensionsChanged {
 			encoder?.finish()
+			// The cached keepalive frame belongs to the retired encoder's geometry.
+			lastOutputBuffer = nil
+			lastKeyFrameAt = -Double.infinity
 			transformer = try PixelBufferTransformer(
 				sourceWidth: sourceWidth,
 				sourceHeight: sourceHeight,
@@ -308,13 +361,34 @@ private final class FramebufferCapture: @unchecked Sendable {
 			droppedFrames += 1
 			return
 		}
-		lastEncodedAt = now
 
 		guard let outputBuffer = transformer.transform(sourceBuffer) else {
 			droppedFrames += 1
 			return
 		}
-		encoder.encode(outputBuffer)
+		// Only a frame that actually reached the encoder should suppress the next keepalive.
+		lastEncodedAt = now
+		lastOutputBuffer = outputBuffer
+		submit(outputBuffer, to: encoder, at: now)
+	}
+
+	private func encodeKeepAliveFrame() {
+		guard let encoder, let outputBuffer = lastOutputBuffer else { return }
+		let now = ProcessInfo.processInfo.systemUptime
+		lastEncodedAt = now
+		submit(outputBuffer, to: encoder, at: now)
+	}
+
+	// Presentation timestamps advance one frame per submission, so VideoToolbox's
+	// MaxKeyFrameIntervalDuration is measured in media time. While idle that runs far slower than the
+	// clock, which would leave a joining client waiting many seconds for a keyframe, so the interval
+	// is enforced against wall time here instead.
+	private func submit(_ buffer: CVPixelBuffer, to encoder: H264Encoder, at now: Double) {
+		let needsKeyFrame = now - lastKeyFrameAt >= idleKeyFrameInterval
+		if needsKeyFrame {
+			lastKeyFrameAt = now
+		}
+		encoder.encode(buffer, forceKeyFrame: needsKeyFrame)
 	}
 
 	private func outputDimensions(sourceWidth: Int, sourceHeight: Int) -> (width: Int, height: Int) {


### PR DESCRIPTION
## The bug

Opening a device panel on an iOS Simulator that is sitting still renders nothing and reports 0 fps. Touching the device fixes it instantly, which makes this look intermittent and environment-dependent — it isn't.

`FramebufferCapture` encodes only from the two CoreSimulator callbacks, `surfaceChanged` and `frameRendered`. Those are damage-driven, so a static screen fires neither and nothing is ever handed to the encoder. Since `/ws/video` calls `OpenVideoStreamAsync` per connection, every client gets its own capture session, and a client that attaches to an idle device receives no frame at all — not a stale one.

Running the helper directly against an untouched simulator shows it plainly. The stats event repeats forever:

```
{"type":"ready","source":"framebuffer","sourceWidth":1206,"sourceHeight":2622,"fps":60,...}
{"type":"stats","bytes":84778,"dropped":0,"encoded":2,"received":0,"surfaceChanges":1}
```

`encoded: 2` is the initial frame from `start()`. The moment the screen changes, the counters move decisively (`received` 0 → 348, `encoded` 2 → 254), which is why any interaction appears to "fix" the panel.

## The fix

An idle keepalive timer on the existing `frameQueue` re-encodes the last frame when nothing has been submitted for 400ms.

Three details that aren't obvious:

**It re-encodes a cached transformed buffer, not the live IOSurface.** The render callbacks are the only signal that a frame has settled. A wall-clock timer has no such guarantee, so transferring straight from the surface could catch the producer mid-update. Caching the last successful `transform()` output also avoids a pool allocation per keepalive.

**The keyframe interval is now enforced against wall time.** Presentation stamps advance one frame per submission, so VideoToolbox measures `MaxKeyFrameIntervalDuration` in *media* time. At the idle frame rate that runs far slower than the clock — a nominal 1s interval becomes tens of seconds of real time — so a client attaching to an idle device would wait a long while for a decodable keyframe. `H264Encoder.encode` already accepted `forceKeyFrame:`; the framebuffer path simply never passed it.

**The idle tick samples `sink.closed`.** An idle stream never reaches `processFrameRendered`, so this was previously the one state in which a departed client was never noticed.

`lastEncodedAt` now updates only after a frame actually reaches the encoder, so a failed transform retries on the next tick instead of being suppressed for a full interval. The cached buffer and keyframe deadline are invalidated when `configure()` rebuilds the encoder, since the snapshot belongs to the retired geometry.

## Verification

Against a completely static simulator screen, `encoded` climbs while `received` stays at 0 — the precise signature of the keepalive doing its job with no callbacks arriving:

```
{"type":"stats","bytes":383511,"dropped":0,"encoded":6,"received":0,"surfaceChanges":1}
{"type":"stats","bytes":735837,"dropped":0,"encoded":11,"received":0,"surfaceChanges":1}
{"type":"stats","bytes":918973,"dropped":0,"encoded":15,"received":0,"surfaceChanges":1}
{"type":"stats","bytes":1277177,"dropped":0,"encoded":19,"received":0,"surfaceChanges":1}
```

NAL analysis of that capture: 73 frames over ~29s (the ~2.5fps idle floor) with 29 IDRs, each preceded by SPS/PPS — one keyframe per second of wall time, as intended.

End-to-end through the host websocket on a static screen: 978 KB across 37 messages in 12s, first bytes at t≈0. Previously zero. The panel renders immediately on attach and stays live.

Interactive behaviour is unchanged: while frames are arriving the idle threshold is never reached, so the keepalive never fires and the existing fps throttle governs.

## Note for maintainers

CI's `source-hash.mjs --check` will fail on this PR. Changing `native/` invalidates the hash recorded in `runtimes/manifest.json`, which only a "Release runtimes" dispatch can refresh — expected for any native change, not a defect in this branch.

There's no native test harness (`tests/` is C# only), so verification here is the empirical capture above. Happy to add coverage if you'd like it somewhere.

Tested on iPhone 17 / iOS 26.5, macOS arm64.
