### PR TITLE
Fix local release packaging

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -118,14 +118,16 @@ Dependencies are restored through
 npm ci --prefix vscode --ignore-scripts
 npm test --prefix vscode
 npm run package --prefix vscode
+./scripts/release.sh
+npm run package:targets --prefix vscode -- --local-only
 ```
 
 The package command writes `.build/mobile-canvas-vscode.vsix` and verifies that
 it contains the checksummed runtime manifest, production web assets, and no test
 or source-map files. It downloads the matching release asset on first use.
-Release CI additionally creates six self-contained platform packages after
-building the native runtimes; VS Code Marketplace selects these packages
-automatically.
+On macOS, the final two commands build both local runtime architectures and
+package self-contained Darwin target VSIXs. Release CI creates all six
+self-contained platform packages; VS Code Marketplace selects them automatically.
 
 To debug interactively, run **Run Mobile Canvas VS Code Extension** from the
 repository's Run and Debug view. The pre-launch task compiles TypeScript and

--- a/lib/runtime-assets.mjs
+++ b/lib/runtime-assets.mjs
@@ -44,6 +44,17 @@ export function remoteRuntimeManifest(manifest) {
   return remote;
 }
 
+export function localRuntimeManifest(manifest) {
+  const local = structuredClone(manifest);
+  local.runtimes = Object.fromEntries(
+    Object.entries(local.runtimes ?? {}).filter(([, entry]) => {
+      const files = Object.values(entry.files ?? {});
+      return files.length > 0 && files.every((file) => file.archive);
+    }),
+  );
+  return local;
+}
+
 export function assertDarwinHelperEntries(
   manifest,
   { context = "runtime manifest", requireAll = true } = {},

--- a/scripts/package-runtime-assets.mjs
+++ b/scripts/package-runtime-assets.mjs
@@ -10,22 +10,43 @@ import {
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { runtimeAssetName, runtimeRelease } from "../lib/runtime-assets.mjs";
+import {
+  localRuntimeManifest,
+  runtimeAssetName,
+  runtimeRelease,
+} from "../lib/runtime-assets.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const runtimes = join(root, "runtimes");
 const output = join(root, ".build", "release-assets");
 const manifest = JSON.parse(readFileSync(join(runtimes, "manifest.json"), "utf8"));
+const args = process.argv.slice(2);
+const unknown = args.filter((arg) => arg !== "--local-only");
+if (unknown.length > 0) {
+  throw new Error(`unknown argument: ${unknown.join(", ")}`);
+}
+const localOnly = args.includes("--local-only");
 const release = runtimeRelease(manifest);
 
 rmSync(output, { recursive: true, force: true });
 mkdirSync(output, { recursive: true });
 
-const releaseManifest = structuredClone(manifest);
+const releaseManifest = localOnly
+  ? localRuntimeManifest(manifest)
+  : structuredClone(manifest);
 releaseManifest.distribution = release;
 const packaged = [];
+const entries = Object.entries(releaseManifest.runtimes ?? {});
 
-for (const [platform, entry] of Object.entries(releaseManifest.runtimes ?? {})) {
+if (entries.length === 0) {
+  throw new Error(
+    localOnly
+      ? "runtime manifest has no fully local runtimes to package"
+      : "runtime manifest has no runtimes to package",
+  );
+}
+
+for (const [platform, entry] of entries) {
   for (const [fileName, file] of Object.entries(entry.files ?? {})) {
     if (!file.archive) {
       throw new Error(`${platform}/${fileName} has no local archive to package`);
@@ -55,4 +76,7 @@ const checksums = packaged
   });
 writeFileSync(join(output, "SHA256SUMS"), `${checksums.join("\n")}\n`);
 
-console.log(`packaged ${packaged.length - 1} runtime assets for ${release.tag} in ${output}`);
+console.log(
+  `packaged ${packaged.length - 1} ${localOnly ? "local " : ""}runtime assets `
+  + `for ${release.tag} in ${output}`,
+);

--- a/scripts/package-vscode-targets.mjs
+++ b/scripts/package-vscode-targets.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { localRuntimeManifest } from "../lib/runtime-assets.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const extensionRoot = join(root, "vscode");
@@ -20,10 +21,21 @@ const supportedTargets = [
 const manifest = JSON.parse(
   readFileSync(join(root, "runtimes", "manifest.json"), "utf8"),
 );
-const targets = supportedTargets.filter((target) => manifest.runtimes?.[target]);
+const args = process.argv.slice(2);
+const unknown = args.filter((arg) => arg !== "--local-only");
+if (unknown.length > 0) {
+  throw new Error(`unknown argument: ${unknown.join(", ")}`);
+}
+const localOnly = args.includes("--local-only");
+const packageManifest = localOnly ? localRuntimeManifest(manifest) : manifest;
+const targets = supportedTargets.filter((target) => packageManifest.runtimes?.[target]);
 
 if (targets.length === 0) {
-  throw new Error("runtime manifest contains no VS Code target platforms");
+  throw new Error(
+    localOnly
+      ? "runtime manifest contains no fully local VS Code target platforms"
+      : "runtime manifest contains no VS Code target platforms",
+  );
 }
 
 try {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,6 +15,19 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
+# Keep remote-only platforms pinned to the checked-in release while replacing
+# the two locally built macOS entries with archives.
+if [[ -z "${MOBILE_CANVAS_RELEASE_TAG:-}" && -f runtimes/manifest.json ]]; then
+  MOBILE_CANVAS_RELEASE_TAG="$(
+    node --input-type=module -e '
+      import { readFileSync } from "node:fs";
+      const manifest = JSON.parse(readFileSync("runtimes/manifest.json", "utf8"));
+      process.stdout.write(manifest.distribution?.tag ?? "");
+    '
+  )"
+  export MOBILE_CANVAS_RELEASE_TAG
+fi
+
 # Native AOT cross-compiles between macOS architectures, so one machine can
 # produce both slices.
 for rid in osx-arm64 osx-x64; do
@@ -23,7 +36,7 @@ for rid in osx-arm64 osx-x64; do
 done
 
 node scripts/verify-bundle.mjs
-npm run package:runtimes
+npm run package:runtimes -- --local-only
 
 printf '\n%s\n' "macOS runtimes and local release assets refreshed."
 printf '%s\n' "Run the Release runtimes workflow to rebuild every supported RID."

--- a/tests/scripts/runtime-assets.test.mjs
+++ b/tests/scripts/runtime-assets.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assertDarwinHelperEntries } from "../../lib/runtime-assets.mjs";
+import {
+  assertDarwinHelperEntries,
+  localRuntimeManifest,
+} from "../../lib/runtime-assets.mjs";
 
 const helper = {
   sha256: "abc",
@@ -34,4 +37,39 @@ test("allows a targeted non-Darwin manifest when requireAll is false", () => {
     { runtimes: { "linux-x64": { files: {} } } },
     { requireAll: false },
   ));
+});
+
+test("local runtime manifest keeps only complete local runtimes", () => {
+  const manifest = {
+    version: "1.2.3",
+    runtimes: {
+      "darwin-arm64": {
+        files: {
+          "mobile-canvas": { archive: "mobile-canvas.gz" },
+          "mobile-screencap": { archive: "mobile-screencap.gz" },
+        },
+      },
+      "darwin-x64": {
+        files: {
+          "mobile-canvas": { archive: "mobile-canvas.gz" },
+          "mobile-screencap": { asset: "mobile-screencap.gz" },
+        },
+      },
+      "linux-x64": {
+        files: {
+          "mobile-canvas": { asset: "mobile-canvas.gz" },
+        },
+      },
+    },
+  };
+
+  const local = localRuntimeManifest(manifest);
+
+  assert.deepEqual(Object.keys(local.runtimes), ["darwin-arm64"]);
+  assert.notEqual(local, manifest);
+  assert.deepEqual(Object.keys(manifest.runtimes), [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-x64",
+  ]);
 });

--- a/vscode/test/prepared-assets.test.mjs
+++ b/vscode/test/prepared-assets.test.mjs
@@ -35,8 +35,15 @@ test("prepared extension assets contain the shared runtime and UI", () => {
   assert.equal(runtimeManifest.version, extensionPackage.version);
   for (const runtime of Object.values(runtimeManifest.runtimes)) {
     for (const file of Object.values(runtime.files)) {
-      assert.equal(file.archive, undefined);
-      assert.match(file.asset, /^mobile-(canvas|screencap)-v.+\.gz$/);
+      if (file.archive) {
+        assert.equal(
+          existsSync(join(extensionRoot, "dist/runtimes", file.archive)),
+          true,
+          file.archive,
+        );
+      } else {
+        assert.match(file.asset, /^mobile-(canvas|screencap)-v.+\.gz$/);
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- preserve the checked-in release tag while rebuilding macOS runtimes locally
- package only fully local runtime assets and target VSIXs during local validation
- cover bundled and remote prepared assets and document the local workflow

## Validation
- `./scripts/release.sh`
- `dotnet test MobileCanvas.slnx -c Release`
- native HID tests for arm64 and x86_64
- `npm test --prefix vscode`
- packaged and installed 0.1.17 previews in both hosts