### PR TITLE
Add native iOS accessibility hierarchy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,7 +20,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-Portions of the CoreSimulator HID implementation are adapted from Meta's idb.
+Portions of the CoreSimulator HID implementation and the CoreSimulator accessibility-hierarchy
+reader are adapted from Meta's idb.
 
 Copyright (c) Meta Platforms, Inc. and affiliates.
 

--- a/README.md
+++ b/README.md
@@ -118,16 +118,18 @@ and take over at any time.
 |---|---|
 | **iOS** | macOS and a full Xcode installation with Simulator runtimes |
 | **Android** | Android SDK with `emulator`, `avdmanager`, and `adb` on `PATH` |
-| **Optional iOS accessibility/fallbacks** | [`idb`](https://fbidb.io) (provides `idb_companion`), plus Screen Recording and Accessibility permission for ScreenCaptureKit window capture |
+| **Optional iOS fallbacks** | [`idb`](https://fbidb.io) (provides `idb_companion`), plus Screen Recording and Accessibility permission for ScreenCaptureKit window capture |
 
 The bundled `mobile-screencap` helper provides iOS touch, keyboard, buttons,
-rotation, and direct video capture. Xcode 26 uses Simulator.app; Xcode 27 uses
-Device Hub. Neither visible app needs to be open for headless input.
+rotation, accessibility hierarchy, and direct video capture. Xcode 26 uses
+Simulator.app; Xcode 27 uses Device Hub. Neither visible app needs to be open
+for headless input or hierarchy reads.
 
-Install Meta's `idb` metapackage only when you need the iOS accessibility
-hierarchy (`ui_tree`, `ui_find`, or `ui_tap`), compatibility input fallback, or
-the final live-video fallback. It provides `idb_companion`; current Homebrew
-versions require explicitly trusting the third-party tap:
+Meta's `idb` metapackage is not required for `ui_tree`, `ui_find`, or `ui_tap`.
+It remains an optional compatibility input fallback and the final live-video
+fallback if the bundled native paths cannot start. Mobile Canvas only reports
+its absence when an operation actually needs it. To install it, current
+Homebrew versions require explicitly trusting the third-party tap:
 
 ```bash
 brew tap facebook/fb
@@ -293,8 +295,8 @@ Two things to know before you change anything:
   directly and is not part of the binary.
 - **`dotnet publish` does not build the Swift helper.** `scripts/build.sh`
   builds both. A stale helper fails only later, at stream start; check it with
-  `mobile-screencap --help` and confirm `framebuffer`, `hid`, `hid-doctor`, and
-  Android's `encode` subcommands exist.
+  `mobile-screencap --help` and confirm `accessibility`, `framebuffer`, `hid`,
+  `hid-doctor`, and Android's `encode` subcommands exist.
 
 Changing `src/` or `native/` requires the **Release runtimes** workflow. It builds
 each Native AOT RID on its native OS, publishes checksummed release assets, and

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -256,6 +256,22 @@ to the app hosting the canvas, and updates never disturb it.
 prompting. If the private framebuffer API changes, capture falls through to
 ScreenCaptureKit and then idb rather than failing.
 
+### Native CoreSimulator accessibility
+
+The bundled helper also reads the frontmost simulator application's
+accessibility hierarchy through CoreSimulator's host-side accessibility
+translation service:
+
+```text
+mobile-screencap accessibility --udid <udid> [--developer-dir <path>]
+```
+
+The command returns bounded nested JSON in logical screen points. The managed
+backend normalizes that payload, and the shared `UiTree` implementation provides
+`ui_find`; `ui_tap` resolves the match to its center and sends it through the
+same native HID path as coordinate input. An installed IDB companion is tried
+silently only if the native hierarchy read fails.
+
 ### Persistent CoreSimulator HID and Xcode 27
 
 The same bundled helper owns iOS input. `mobile-screencap hid --udid <udid>`
@@ -291,10 +307,12 @@ separate concerns:
   optional visible simulator host while preserving Simulator.app support for
   Xcode 26.
 
-`idb_companion` remains optional. It supplies the accessibility hierarchy,
-compatibility input fallback when native HID cannot start before delivery, and
-the final live-video fallback. A native failure after an event may have been
-delivered is surfaced directly and is never replayed through IDB.
+`idb_companion` remains optional. It supplies compatibility input fallback when
+native HID cannot start before delivery, a hierarchy fallback if the bundled
+reader cannot run against a changed CoreSimulator, and the final live-video
+fallback. Its absence is reported only when one of those fallbacks is required.
+A native input failure after an event may have been delivered is surfaced
+directly and is never replayed through IDB.
 
 ## Supported platforms
 

--- a/native/mobile-screencap/Sources/AccessibilityCommand.swift
+++ b/native/mobile-screencap/Sources/AccessibilityCommand.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// `mobile-screencap accessibility --udid <udid> [--developer-dir <path>] [--max-depth <n>]
+/// [--max-nodes <n>] [--timeout <seconds>]`
+///
+/// A single-shot read of the frontmost iOS Simulator application's accessibility hierarchy from
+/// the host side, without `idb_companion`. Success writes the tree itself as one JSON object to
+/// stdout, in the dictionary shape the managed `AccessibilityParser` already understands
+/// (`role`/`type`, `AXLabel`, `AXValue`, `AXUniqueId`, `help`, `frame`, `enabled`, `focused`,
+/// `children`). A failure instead writes a single `{"type":"unavailable","code":...,"message":...}`
+/// line and exits non-zero, mirroring the `hid`/`hid-doctor` "unavailable" frame convention so a
+/// managed caller can tell a startup failure from a truncated/empty success apart without parsing
+/// stderr.
+enum AccessibilityCommand {
+	/// The root counts as depth 0; this keeps a runaway or adversarial UI tree from producing an
+	/// unbounded response.
+	static let defaultMaxDepth = 64
+	/// A generous ceiling for a single screen's worth of UI while still bounding worst-case size
+	/// and serialization time.
+	static let defaultMaxNodes = 20_000
+	/// How long a single request is allowed to wait on the simulator's translation round trip.
+	static let defaultRequestTimeout: TimeInterval = 5.0
+
+	static func run(_ options: CommandLineOptions) throws -> Never {
+		guard let udid = options.string("udid"), !udid.isEmpty else {
+			emitUnavailable(code: "invalid_request", message: "--udid is required")
+			exit(2)
+		}
+
+		let maxDepth = clampInt(options.int("max-depth") ?? defaultMaxDepth, min: 0, max: 4096)
+		let maxNodes = clampInt(options.int("max-nodes") ?? defaultMaxNodes, min: 1, max: 200_000)
+		let requestTimeout = clampTimeout(options.double("timeout") ?? defaultRequestTimeout)
+
+		let developerDirectory: String
+		do {
+			developerDirectory = try DeveloperDirectory.resolve(options.string("developer-dir"))
+		} catch {
+			emitUnavailable(code: "device_unavailable", message: "\(error)")
+			exit(1)
+		}
+
+		guard MCSimulatorDevice.isCoreSimulatorAvailable else {
+			emitUnavailable(
+				code: "device_unavailable", message: "CoreSimulator is unavailable in this process")
+			exit(1)
+		}
+
+		let device: MCSimulatorDevice
+		do {
+			device = try MCSimulatorDevice.lookUp(udid: udid, developerDirectory: developerDirectory)
+		} catch {
+			emitUnavailable(code: "device_unavailable", message: (error as NSError).localizedDescription)
+			exit(1)
+		}
+
+		guard device.isBooted else {
+			let state = device.stateDescription ?? "unknown"
+			emitUnavailable(
+				code: "device_not_booted",
+				message: "simulator \(udid) is not booted (state: \(state))")
+			exit(1)
+		}
+
+		guard MCAccessibilityReader.isAvailable else {
+			emitUnavailable(
+				code: "framework_unavailable",
+				message: MCAccessibilityReader.unavailableReason
+					?? "the accessibility translation framework is unavailable on this host")
+			exit(1)
+		}
+
+		do {
+			let tree = try MCAccessibilityReader.accessibilityTree(
+				device: device, maxDepth: maxDepth, maxNodes: maxNodes, requestTimeout: requestTimeout)
+			let data = try JSONSerialization.data(
+				withJSONObject: tree, options: [.prettyPrinted, .sortedKeys])
+			FileHandle.standardOutput.write(data)
+			FileHandle.standardOutput.write(Data("\n".utf8))
+			exit(0)
+		} catch let error as NSError where error.domain == MCAccessibilityErrorDomain {
+			emitUnavailable(code: errorCode(forRawValue: error.code), message: error.localizedDescription)
+			exit(1)
+		} catch {
+			emitUnavailable(code: "internal_error", message: "\(error)")
+			exit(1)
+		}
+	}
+
+	/// Maps `MCAccessibilityErrorCode` (declared in `SimulatorAccessibilityBridge.h`) to a stable
+	/// string a managed caller can switch on. Matched against the raw integer rather than the
+	/// imported Swift enum case so this stays correct regardless of how Swift happens to spell an
+	/// individual case name.
+	static func errorCode(forRawValue rawValue: Int) -> String {
+		switch rawValue {
+		case 1: return "framework_unavailable"
+		case 2: return "selector_unavailable"
+		case 3: return "device_not_booted"
+		case 4: return "timeout"
+		case 5: return "empty_tree"
+		default: return "internal_error"
+		}
+	}
+
+	static func clampInt(_ value: Int, min lower: Int, max upper: Int) -> Int {
+		Swift.min(Swift.max(value, lower), upper)
+	}
+
+	static func clampTimeout(_ value: Double) -> TimeInterval {
+		guard value.isFinite else { return defaultRequestTimeout }
+		return Swift.min(Swift.max(value, 0.1), 60.0)
+	}
+
+	private static func emitUnavailable(code: String, message: String) {
+		let payload: [String: Any] = ["type": "unavailable", "code": code, "message": message]
+		guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+		else {
+			return
+		}
+		FileHandle.standardOutput.write(data)
+		FileHandle.standardOutput.write(Data("\n".utf8))
+	}
+}

--- a/native/mobile-screencap/Sources/Bridging.h
+++ b/native/mobile-screencap/Sources/Bridging.h
@@ -3,3 +3,4 @@
 #import "SimulatorDeviceBridge.h"
 #import "SimulatorIndigoHid.h"
 #import "SimulatorDtuHid.h"
+#import "SimulatorAccessibilityBridge.h"

--- a/native/mobile-screencap/Sources/Entry.swift
+++ b/native/mobile-screencap/Sources/Entry.swift
@@ -46,6 +46,8 @@ struct MobileScreencap {
 					try HidCommand.run(options)
 				case "hid-doctor":
 					try HidDoctorCommand.run(options)
+				case "accessibility":
+					try AccessibilityCommand.run(options)
 				case "doctor":
 					try await runDoctor()
 				case "--help", "-h", "help":
@@ -81,6 +83,7 @@ struct MobileScreencap {
 			  rotate                   Rotate an iOS Simulator device.
 			  hid                      Persistent NDJSON HID session on stdin/stdout.
 			  hid-doctor               Report bundled HID transport negotiability as JSON.
+			  accessibility            Print the frontmost app's accessibility tree as JSON.
 
 			Framebuffer options:
 			  --udid <udid>            Simulator UDID. Required.
@@ -111,6 +114,14 @@ struct MobileScreencap {
 			HID options:
 			  --udid <udid>            Simulator device identifier. Required.
 			  --developer-dir <path>   Override the selected developer directory.
+
+			Accessibility options:
+			  --udid <udid>            Simulator device identifier. Required.
+			  --developer-dir <path>   Override the selected developer directory.
+			  --max-depth <n>          Maximum tree depth (root is 0). Default 64.
+			  --max-nodes <n>          Maximum total nodes returned. Default 20000.
+			  --timeout <seconds>      Max wait for the simulator's translation round trip.
+			                           Default 5.0.
 
 			"""
 		FileHandle.standardError.write(Data(usage.utf8))

--- a/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.h
+++ b/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.h
@@ -86,4 +86,13 @@ extern NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id 
                                                                               NSInteger maxDepth,
                                                                               NSInteger maxNodes);
 
+/// Token-aware form used by the live translator path. The token is attached to each translated
+/// element before any lazy accessibility attribute is read; returns `nil` if an element cannot
+/// carry the token so the managed caller can fall back to IDB instead of accepting a partial tree.
+extern NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElementWithBridgeDelegateToken(
+    id element,
+    NSInteger maxDepth,
+    NSInteger maxNodes,
+    NSString *bridgeDelegateToken);
+
 NS_ASSUME_NONNULL_END

--- a/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.h
+++ b/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.h
@@ -1,0 +1,89 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MCSimulatorDevice;
+
+/// Error domain for `MCAccessibilityReader`, distinct from `MCSimulatorErrorDomain` so a caller can
+/// tell an accessibility-specific failure apart from a general CoreSimulator one.
+extern NSString *const MCAccessibilityErrorDomain;
+
+/// Stable codes a Swift caller can switch on without parsing `localizedDescription`.
+typedef NS_ENUM(NSInteger, MCAccessibilityErrorCode) {
+    /// `AccessibilityPlatformTranslation.framework` could not be loaded on this host.
+    MCAccessibilityErrorFrameworkUnavailable = 1,
+    /// The framework loaded, but a required class/selector is missing (an older OS/Xcode).
+    MCAccessibilityErrorSelectorUnavailable = 2,
+    /// The simulator device is not in the `Booted` state.
+    MCAccessibilityErrorDeviceNotBooted = 3,
+    /// The bounded wait for a translation response elapsed.
+    MCAccessibilityErrorTimeout = 4,
+    /// The translator reported no frontmost application (nothing to read).
+    MCAccessibilityErrorEmptyTree = 5,
+    /// An unexpected failure (including a caught `NSException`) while translating or walking the
+    /// tree.
+    MCAccessibilityErrorInternal = 6,
+};
+
+/// Reads the frontmost iOS Simulator application's accessibility hierarchy from the host side,
+/// without `idb_companion`.
+///
+/// Adapted from Meta's idb (`FBAXTranslationDispatcher`, `FBSimulatorAccessibilityCommands`,
+/// `FBAXPlatformElement`, `FBAccessibilityDocument`; MIT license) -- see the repository LICENSE.
+/// Unlike idb this reader:
+///  - is `dlopen`ed/declared at runtime rather than linked against a vendored framework binding,
+///  - only walks the frontmost application's tree (no point/hit-test queries, remote-content
+///    synthesis, coverage grids, or SpringBoard-crash remediation), and
+///  - serializes directly to the dictionary shape `AccessibilityParser` (managed side) already
+///    understands, rather than idb's full attributed-string/traits/actions payload.
+@interface MCAccessibilityReader : NSObject
+
+/// Whether `AccessibilityPlatformTranslation` could be loaded and `SimDevice` exposes the
+/// translation-request selector in this process. `NO` is definitive and device-independent; it
+/// generally means an Xcode/CoreSimulator older than the one that introduced this path.
+@property (class, nonatomic, readonly, getter=isAvailable) BOOL available;
+
+/// Why `available` is `NO`, or `nil` when it is `YES`.
+@property (class, nonatomic, readonly, nullable) NSString *unavailableReason;
+
+/// Reads the frontmost application's accessibility tree as a JSON-serializable dictionary tree.
+///
+/// - `maxDepth`: the root counts as depth `0`; children beyond `maxDepth` are cut off (their
+///   parent still reports `children: []`, never a mix of the real count and a partial list).
+/// - `maxNodes`: a running budget across the whole traversal (root included); traversal stops
+///   filling further siblings/children once it is exhausted rather than throwing, since a
+///   truncated-but-well-formed tree is more useful to a caller than none at all.
+/// - `requestTimeout`: the most this call will wait for a single translator round trip.
+///
+/// Returns `nil` and sets `error` (in `MCAccessibilityErrorDomain`) when the framework/selector is
+/// unavailable, the device is not booted, the wait times out, or there is no frontmost application.
++ (nullable NSDictionary<NSString *, id> *)accessibilityTreeForDevice:(MCSimulatorDevice *)device
+                                                               maxDepth:(NSInteger)maxDepth
+                                                               maxNodes:(NSInteger)maxNodes
+                                                         requestTimeout:(NSTimeInterval)requestTimeout
+                                                                  error:(NSError **)error
+    NS_SWIFT_NAME(accessibilityTree(device:maxDepth:maxNodes:requestTimeout:));
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+/// Serializes a single accessibility element (and its accessible children, subject to the same
+/// `maxDepth`/`maxNodes` bounds `MCAccessibilityReader` applies) into the dictionary shape
+/// `AccessibilityParser` understands. `element` must respond to the same duck-typed
+/// `NSAccessibility` selectors (`accessibilityRole`, `accessibilityLabel`, `accessibilityChildren`,
+/// ...) the reader itself uses; it is declared as a plain `id` rather than `id<NSAccessibility>` so
+/// a fake test object does not have to formally (and expensively, given how large that protocol
+/// has grown) declare conformance -- exactly like the real translated elements this reads from,
+/// which never declare it either.
+///
+/// Exposed separately from `MCAccessibilityReader` because it has no CoreSimulator/`dlopen`
+/// dependency at all -- it is plain, public `NSAccessibility` traversal -- so tests can exercise the
+/// exact bounding and serialization logic the real reader uses against a fake element, without a
+/// booted simulator. `MCAccessibilityReader` itself calls this same function on the real
+/// translated tree.
+extern NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id element,
+                                                                              NSInteger maxDepth,
+                                                                              NSInteger maxNodes);
+
+NS_ASSUME_NONNULL_END

--- a/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.m
+++ b/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.m
@@ -83,6 +83,32 @@ static BOOL MCLoadAccessibilityPlatformTranslation(NSString *_Nullable *_Nullabl
 - (nullable id)macPlatformElementFromTranslation:(nullable id)translation;
 @end
 
+@protocol MCAXPTranslationObject <NSObject>
+@property (nonatomic, copy, nullable) NSString *bridgeDelegateToken;
+@end
+
+@protocol MCAXPMacPlatformElement <NSObject>
+@property (nonatomic, strong, readonly, nullable) id<MCAXPTranslationObject> translation;
+@end
+
+static BOOL MCSetTranslationBridgeDelegateToken(id _Nullable translation, NSString *token)
+{
+    if (![translation respondsToSelector:@selector(setBridgeDelegateToken:)]) {
+        return NO;
+    }
+    [(id<MCAXPTranslationObject>)translation setBridgeDelegateToken:token];
+    return YES;
+}
+
+static BOOL MCSetElementBridgeDelegateToken(id _Nullable element, NSString *token)
+{
+    if (![element respondsToSelector:@selector(translation)]) {
+        return NO;
+    }
+    id translation = [(id<MCAXPMacPlatformElement>)element translation];
+    return MCSetTranslationBridgeDelegateToken(translation, token);
+}
+
 #pragma mark - Bounded per-token XPC bridge
 
 /// Per-read bookkeeping keyed by a one-shot token: which device to route a translation request to,
@@ -394,9 +420,13 @@ static id _Nullable MCConvertAccessibilityValue(id _Nullable value)
 static NSDictionary<NSString *, id> *_Nullable MCBuildAccessibilityNode(id<NSAccessibility> element,
                                                                          NSInteger depth,
                                                                          NSInteger maxDepth,
-                                                                         NSInteger *remainingNodes)
+                                                                         NSInteger *remainingNodes,
+                                                                         NSString *_Nullable bridgeDelegateToken)
 {
     if (*remainingNodes <= 0) {
+        return nil;
+    }
+    if (bridgeDelegateToken != nil && !MCSetElementBridgeDelegateToken(element, bridgeDelegateToken)) {
         return nil;
     }
     (*remainingNodes)--;
@@ -461,9 +491,12 @@ static NSDictionary<NSString *, id> *_Nullable MCBuildAccessibilityNode(id<NSAcc
                 continue;
             }
             NSDictionary<NSString *, id> *childNode =
-                MCBuildAccessibilityNode((id<NSAccessibility>)child, depth + 1, maxDepth, remainingNodes);
+                MCBuildAccessibilityNode((id<NSAccessibility>)child, depth + 1, maxDepth, remainingNodes,
+                                         bridgeDelegateToken);
             if (childNode != nil) {
                 [children addObject:childNode];
+            } else if (bridgeDelegateToken != nil) {
+                return nil;
             }
         }
     }
@@ -477,7 +510,18 @@ NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id element
                                                                        NSInteger maxNodes)
 {
     NSInteger remaining = MAX(maxNodes, 1);
-    return MCBuildAccessibilityNode((id<NSAccessibility>)element, 0, MAX(maxDepth, 0), &remaining);
+    return MCBuildAccessibilityNode((id<NSAccessibility>)element, 0, MAX(maxDepth, 0), &remaining, nil);
+}
+
+NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElementWithBridgeDelegateToken(
+    id element,
+    NSInteger maxDepth,
+    NSInteger maxNodes,
+    NSString *bridgeDelegateToken)
+{
+    NSInteger remaining = MAX(maxNodes, 1);
+    return MCBuildAccessibilityNode((id<NSAccessibility>)element, 0, MAX(maxDepth, 0), &remaining,
+                                    bridgeDelegateToken);
 }
 
 #pragma mark - MCAccessibilityReader
@@ -548,6 +592,14 @@ NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id element
         @try {
             [translator setBridgeTokenDelegate:delegate];
             id application = [translator frontmostApplicationWithDisplayId:0 bridgeDelegateToken:token];
+            if (application != nil && !MCSetTranslationBridgeDelegateToken(application, token)) {
+                if (error != NULL) {
+                    *error = MCAccessibilityError(
+                        MCAccessibilityErrorSelectorUnavailable,
+                        @"The accessibility translation object does not expose bridgeDelegateToken", nil);
+                }
+                return nil;
+            }
             id root = application != nil ? [translator macPlatformElementFromTranslation:application] : nil;
 
             if (root == nil || ![root isKindOfClass:NSObject.class]) {
@@ -572,7 +624,8 @@ NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id element
             }
 
             NSDictionary<NSString *, id> *tree =
-                MCAccessibilityNodeForElement((id<NSAccessibility>)root, maxDepth, maxNodes);
+                MCAccessibilityNodeForElementWithBridgeDelegateToken(
+                    (id<NSAccessibility>)root, maxDepth, maxNodes, token);
 
             if ([delegate didTimeOutForToken:token]) {
                 if (error != NULL) {

--- a/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.m
+++ b/native/mobile-screencap/Sources/SimulatorAccessibilityBridge.m
@@ -1,0 +1,620 @@
+#import "SimulatorAccessibilityBridge.h"
+
+#import "SimulatorDeviceBridge.h"
+#import "SimulatorPrivateAPI.h"
+
+#import <AppKit/AppKit.h>
+#import <dlfcn.h>
+
+// Adapted from Meta's idb FBAXTranslationDispatcher, FBSimulatorAccessibilityCommands,
+// FBAXPlatformElement, and FBAccessibilityDocument (MIT); see the repository LICENSE.
+//
+// Unlike idb, none of `AXPTranslator`, `AXPTranslatorRequest`/`AXPTranslatorResponse`, or the
+// `AXPTranslationTokenDelegateHelper` protocol are declared against the real framework: this file
+// never links `AccessibilityPlatformTranslation`, only `dlopen`s it, and every private type is
+// either an informal protocol resolved through `NSClassFromString`/`respondsToSelector:` or plain
+// `id`. `AXPTranslatorRequest`/`AXPTranslatorResponse` in particular never need a name here at
+// all -- `AXPTranslator` builds the request and hands it to `accessibilityTranslationDelegateBridgeCallbackWithToken:`'s
+// returned block, which only has to forward it verbatim to `SimDevice
+// sendAccessibilityRequestAsync:` and hand the response back, so both stay untyped `id`.
+
+NSString *const MCAccessibilityErrorDomain = @"com.github.copilot.mobile-canvas.accessibility";
+
+static NSError *MCAccessibilityError(MCAccessibilityErrorCode code, NSString *description, id _Nullable underlying)
+{
+    NSMutableDictionary *details = [@{NSLocalizedDescriptionKey: description} mutableCopy];
+    if ([underlying isKindOfClass:NSError.class]) {
+        details[NSUnderlyingErrorKey] = underlying;
+    } else if (underlying != nil) {
+        details[@"UnderlyingDescription"] = [underlying description];
+    }
+    return [NSError errorWithDomain:MCAccessibilityErrorDomain code:code userInfo:details];
+}
+
+static NSString *const MCAXPFrameworkPath =
+    @"/System/Library/PrivateFrameworks/AccessibilityPlatformTranslation.framework/AccessibilityPlatformTranslation";
+
+/// Loads `AccessibilityPlatformTranslation` once per process.
+///
+/// The Xcode SDK only ships a link-time `.tbd` stub for this framework; the real binary lives in
+/// the dyld shared cache with no standalone Mach-O on disk, and is only reachable at this fixed
+/// system path (confirmed by probing `dlopen` directly against a running `mobile-screencap`
+/// process), unlike `SimulatorKit`/`CoreSimulator`, which are developer-directory-relative.
+static BOOL MCLoadAccessibilityPlatformTranslation(NSString *_Nullable *_Nullable failureDetail)
+{
+    static BOOL loaded = NO;
+    static NSString *detail = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        void *handle = dlopen(MCAXPFrameworkPath.fileSystemRepresentation, RTLD_LAZY | RTLD_LOCAL);
+        if (handle == NULL) {
+            const char *dlError = dlerror();
+            detail = [NSString stringWithFormat:@"AccessibilityPlatformTranslation could not be loaded from %@%@",
+                                                 MCAXPFrameworkPath,
+                                                 dlError != NULL
+                                                     ? [NSString stringWithFormat:@": %s", dlError]
+                                                     : @""];
+            return;
+        }
+        loaded = NSClassFromString(@"AXPTranslator") != nil;
+        if (!loaded) {
+            detail = @"AccessibilityPlatformTranslation loaded, but AXPTranslator is not present";
+        }
+    });
+    if (!loaded && failureDetail != NULL) {
+        *failureDetail = detail;
+    }
+    return loaded;
+}
+
+#pragma mark - Informal declarations for the runtime-only AXPTranslator
+
+/// `AXPTranslator`'s class side. Declared as a protocol -- never a class literal -- so nothing here
+/// requires (or emits a link-time reference to) the real `AXPTranslator` symbol.
+@protocol MCAXPTranslatorClass <NSObject>
++ (nullable id)sharedInstance;
+@end
+
+/// `AXPTranslator`'s instance side; the handful of methods this reader actually calls.
+@protocol MCAXPTranslator <NSObject>
+- (void)setBridgeTokenDelegate:(nullable id)delegate;
+- (nullable id)frontmostApplicationWithDisplayId:(uint32_t)displayId
+                             bridgeDelegateToken:(nullable NSString *)token;
+- (nullable id)macPlatformElementFromTranslation:(nullable id)translation;
+@end
+
+#pragma mark - Bounded per-token XPC bridge
+
+/// Per-read bookkeeping keyed by a one-shot token: which device to route a translation request to,
+/// how long to wait for it, and whether that wait ever failed.
+@interface MCAXRequestContext : NSObject
+@property (nonatomic, strong) id device;
+@property (nonatomic, assign) NSTimeInterval timeout;
+@property (nonatomic, assign) BOOL timedOut;
+@property (nonatomic, assign) BOOL requestFailed;
+@end
+
+@implementation MCAXRequestContext
+@end
+
+/// Implements the framework's private `AXPTranslationTokenDelegateHelper` protocol informally (by
+/// selector name only -- the real protocol is never imported) and bridges its synchronous callback
+/// to `SimDevice sendAccessibilityRequestAsync:completionQueue:completionHandler:`.
+///
+/// `AXPTranslator` is a process-wide singleton with a single `bridgeTokenDelegate`, so this is a
+/// singleton too; the token registry lets one delegate instance serve reads for different devices
+/// without them racing each other's timeout/failure bookkeeping.
+@interface MCAXTranslationDelegate : NSObject
+@property (nonatomic, strong, readonly) dispatch_queue_t completionQueue;
+@end
+
+@implementation MCAXTranslationDelegate {
+    NSLock *_lock;
+    NSMutableDictionary<NSString *, MCAXRequestContext *> *_contexts;
+}
+
++ (instancetype)sharedDelegate
+{
+    static MCAXTranslationDelegate *delegate = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        delegate = [[MCAXTranslationDelegate alloc] initInternal];
+    });
+    return delegate;
+}
+
+- (instancetype)initInternal
+{
+    self = [super init];
+    if (self != nil) {
+        _lock = [[NSLock alloc] init];
+        _contexts = [NSMutableDictionary dictionary];
+        _completionQueue = dispatch_queue_create("dev.mobilecanvas.accessibility.completion", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+- (NSString *)registerDevice:(id)device timeout:(NSTimeInterval)timeout
+{
+    NSString *token = [NSUUID UUID].UUIDString;
+    MCAXRequestContext *context = [[MCAXRequestContext alloc] init];
+    context.device = device;
+    context.timeout = timeout;
+    [_lock lock];
+    _contexts[token] = context;
+    [_lock unlock];
+    return token;
+}
+
+- (void)unregisterToken:(NSString *)token
+{
+    [_lock lock];
+    [_contexts removeObjectForKey:token];
+    [_lock unlock];
+}
+
+- (nullable MCAXRequestContext *)contextForToken:(NSString *)token
+{
+    [_lock lock];
+    MCAXRequestContext *context = _contexts[token];
+    [_lock unlock];
+    return context;
+}
+
+- (BOOL)didTimeOutForToken:(NSString *)token
+{
+    return [self contextForToken:token].timedOut;
+}
+
+- (BOOL)didRequestFailForToken:(NSString *)token
+{
+    return [self contextForToken:token].requestFailed;
+}
+
+#pragma mark AXPTranslationTokenDelegateHelper (informal)
+
+/// The simulator host process has exactly one coordinate space, so platform and system frames are
+/// the same rect; idb's own dispatcher makes the same simplification.
+- (CGRect)accessibilityTranslationConvertPlatformFrameToSystem:(CGRect)rect withToken:(NSString *)token
+{
+    return rect;
+}
+
+/// The frontmost application is the traversal's own root, so it has no accessibility parent.
+- (nullable id)accessibilityTranslationRootParentWithToken:(NSString *)token
+{
+    return nil;
+}
+
+/// Returns the synchronous `(request) -> response` block `AXPTranslator` invokes (from its own
+/// internal queue, not ours) whenever it needs a translation round trip for `token`.
+- (id)accessibilityTranslationDelegateBridgeCallbackWithToken:(NSString *)token
+{
+    __weak MCAXTranslationDelegate *weakSelf = self;
+    NSString *capturedToken = [token copy];
+    id (^callback)(id) = ^id(id request) {
+        return [weakSelf sendRequest:request forToken:capturedToken];
+    };
+    return [callback copy];
+}
+
+#pragma mark Bounded synchronous send
+
+/// Bridges the translator's synchronous callback to the async `sendAccessibilityRequestAsync:`,
+/// waiting at most the registered timeout. The completion runs on `completionQueue`, never on the
+/// thread that is waiting on `semaphore`, so there is no self-deadlock.
+- (nullable id)sendRequest:(id)request forToken:(NSString *)token
+{
+    MCAXRequestContext *context = [self contextForToken:token];
+    if (context == nil || request == nil) {
+        return nil;
+    }
+
+    id device = context.device;
+    if (![device respondsToSelector:@selector(sendAccessibilityRequestAsync:completionQueue:completionHandler:)]) {
+        context.requestFailed = YES;
+        return nil;
+    }
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    __block id response = nil;
+    @try {
+        [device sendAccessibilityRequestAsync:request
+                               completionQueue:self.completionQueue
+                             completionHandler:^(id _Nullable value) {
+                                 response = value;
+                                 dispatch_semaphore_signal(semaphore);
+                             }];
+    } @catch (__unused NSException *exception) {
+        context.requestFailed = YES;
+        dispatch_semaphore_signal(semaphore);
+        return nil;
+    }
+
+    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MAX(context.timeout, 0.0) * NSEC_PER_SEC));
+    if (dispatch_semaphore_wait(semaphore, deadline) != 0) {
+        context.timedOut = YES;
+        return nil;
+    }
+    return response;
+}
+
+@end
+
+#pragma mark - Bounded traversal over the public NSAccessibility protocol
+
+// `AXPMacPlatformElement` (the class `macPlatformElementFromTranslation:` returns) implements a few
+// modern NSAccessibility selectors directly and relies on AppKit's `NSObject(NSAccessibility)`
+// category -- which every `NSObject` picks up simply by linking AppKit, already true for this
+// helper -- to forward the rest to its own legacy `accessibilityAttributeValue:` override. So,
+// unlike `AXPTranslator` itself, no private declarations are needed to read attributes: these are
+// all genuine public AppKit selectors.
+
+static NSString *_Nullable MCAXStringSelector(BOOL (^responds)(void), NSString *_Nullable (^read)(void))
+{
+    if (!responds()) {
+        return nil;
+    }
+    @try {
+        NSString *value = read();
+        return [value isKindOfClass:NSString.class] && value.length > 0 ? value : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSString *_Nullable MCAXRole(id<NSAccessibility> element)
+{
+    return MCAXStringSelector(
+        ^BOOL { return [element respondsToSelector:@selector(accessibilityRole)]; },
+        ^NSString *_Nullable { return [element accessibilityRole]; });
+}
+
+static NSString *_Nullable MCAXSubrole(id<NSAccessibility> element)
+{
+    return MCAXStringSelector(
+        ^BOOL { return [element respondsToSelector:@selector(accessibilitySubrole)]; },
+        ^NSString *_Nullable { return [element accessibilitySubrole]; });
+}
+
+static NSString *_Nullable MCAXLabel(id<NSAccessibility> element)
+{
+    return MCAXStringSelector(
+        ^BOOL { return [element respondsToSelector:@selector(accessibilityLabel)]; },
+        ^NSString *_Nullable { return [element accessibilityLabel]; });
+}
+
+static NSString *_Nullable MCAXIdentifier(id<NSAccessibility> element)
+{
+    return MCAXStringSelector(
+        ^BOOL { return [element respondsToSelector:@selector(accessibilityIdentifier)]; },
+        ^NSString *_Nullable { return [element accessibilityIdentifier]; });
+}
+
+static NSString *_Nullable MCAXHelp(id<NSAccessibility> element)
+{
+    return MCAXStringSelector(
+        ^BOOL { return [element respondsToSelector:@selector(accessibilityHelp)]; },
+        ^NSString *_Nullable { return [element accessibilityHelp]; });
+}
+
+static id _Nullable MCAXValue(id<NSAccessibility> element)
+{
+    if (![element respondsToSelector:@selector(accessibilityValue)]) {
+        return nil;
+    }
+    @try {
+        return [element accessibilityValue];
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static BOOL MCAXFrame(id<NSAccessibility> element, NSRect *outFrame)
+{
+    if (![element respondsToSelector:@selector(accessibilityFrame)]) {
+        return NO;
+    }
+    @try {
+        *outFrame = [element accessibilityFrame];
+        return YES;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL MCAXEnabled(id<NSAccessibility> element, BOOL *outValue)
+{
+    if (![element respondsToSelector:@selector(isAccessibilityEnabled)]) {
+        return NO;
+    }
+    @try {
+        *outValue = [element isAccessibilityEnabled];
+        return YES;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL MCAXFocused(id<NSAccessibility> element, BOOL *outValue)
+{
+    if (![element respondsToSelector:@selector(isAccessibilityFocused)]) {
+        return NO;
+    }
+    @try {
+        *outValue = [element isAccessibilityFocused];
+        return YES;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
+static NSArray *_Nullable MCAXChildren(id<NSAccessibility> element)
+{
+    if (![element respondsToSelector:@selector(accessibilityChildren)]) {
+        return nil;
+    }
+    @try {
+        id value = [element accessibilityChildren];
+        return [value isKindOfClass:NSArray.class] ? value : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+/// Strips the "AX" prefix idb/AppKit roles carry (`AXButton` -> `Button`), matching the managed
+/// `AccessibilityParser`'s own historical `type` spelling. Left untouched when there is no prefix.
+static NSString *_Nullable MCNormalizeRole(NSString *_Nullable role)
+{
+    if (role.length > 2 && [role hasPrefix:@"AX"]) {
+        return [role substringFromIndex:2];
+    }
+    return role;
+}
+
+/// `accessibilityValue` can answer with anything (a string, a number, a custom value object for a
+/// slider/stepper, ...); only JSON-native kinds are passed through unchanged; everything else
+/// degrades to its `description` rather than failing serialization or silently vanishing.
+static id _Nullable MCConvertAccessibilityValue(id _Nullable value)
+{
+    if (value == nil || [value isKindOfClass:NSNull.class]) {
+        return nil;
+    }
+    if ([value isKindOfClass:NSString.class] || [value isKindOfClass:NSNumber.class]) {
+        return value;
+    }
+    NSString *description = [value description];
+    return description.length > 0 ? description : nil;
+}
+
+/// Depth-first, bounded by `maxDepth` (root is depth `0`) and a running `remainingNodes` budget
+/// shared across the whole traversal (root included). Once the budget is spent, further
+/// siblings/children are simply omitted -- a truncated well-formed tree beats an error or a
+/// half-built one.
+static NSDictionary<NSString *, id> *_Nullable MCBuildAccessibilityNode(id<NSAccessibility> element,
+                                                                         NSInteger depth,
+                                                                         NSInteger maxDepth,
+                                                                         NSInteger *remainingNodes)
+{
+    if (*remainingNodes <= 0) {
+        return nil;
+    }
+    (*remainingNodes)--;
+
+    NSMutableDictionary<NSString *, id> *node = [NSMutableDictionary dictionary];
+
+    NSString *role = MCAXRole(element);
+    if (role != nil) {
+        node[@"role"] = role;
+        NSString *normalized = MCNormalizeRole(role);
+        if (normalized != nil) {
+            node[@"type"] = normalized;
+        }
+    }
+    NSString *subrole = MCAXSubrole(element);
+    if (subrole != nil) {
+        node[@"subrole"] = subrole;
+    }
+    NSString *label = MCAXLabel(element);
+    if (label != nil) {
+        node[@"AXLabel"] = label;
+    }
+    id value = MCConvertAccessibilityValue(MCAXValue(element));
+    if (value != nil) {
+        node[@"AXValue"] = value;
+    }
+    NSString *identifier = MCAXIdentifier(element);
+    if (identifier != nil) {
+        node[@"AXUniqueId"] = identifier;
+    }
+    NSString *help = MCAXHelp(element);
+    if (help != nil) {
+        node[@"help"] = help;
+    }
+
+    NSRect frame;
+    if (MCAXFrame(element, &frame)) {
+        node[@"frame"] = @{
+            @"x": @(frame.origin.x),
+            @"y": @(frame.origin.y),
+            @"width": @(frame.size.width),
+            @"height": @(frame.size.height),
+        };
+    }
+
+    BOOL enabled;
+    if (MCAXEnabled(element, &enabled)) {
+        node[@"enabled"] = @(enabled);
+    }
+    BOOL focused;
+    if (MCAXFocused(element, &focused)) {
+        node[@"focused"] = @(focused);
+    }
+
+    NSMutableArray<NSDictionary<NSString *, id> *> *children = [NSMutableArray array];
+    if (depth < maxDepth) {
+        for (id child in MCAXChildren(element) ?: @[]) {
+            if (*remainingNodes <= 0) {
+                break;
+            }
+            if (![child isKindOfClass:NSObject.class]) {
+                continue;
+            }
+            NSDictionary<NSString *, id> *childNode =
+                MCBuildAccessibilityNode((id<NSAccessibility>)child, depth + 1, maxDepth, remainingNodes);
+            if (childNode != nil) {
+                [children addObject:childNode];
+            }
+        }
+    }
+    node[@"children"] = children;
+
+    return node;
+}
+
+NSDictionary<NSString *, id> *_Nullable MCAccessibilityNodeForElement(id element,
+                                                                       NSInteger maxDepth,
+                                                                       NSInteger maxNodes)
+{
+    NSInteger remaining = MAX(maxNodes, 1);
+    return MCBuildAccessibilityNode((id<NSAccessibility>)element, 0, MAX(maxDepth, 0), &remaining);
+}
+
+#pragma mark - MCAccessibilityReader
+
+@implementation MCAccessibilityReader
+
++ (BOOL)isAvailable
+{
+    return MCLoadAccessibilityPlatformTranslation(NULL);
+}
+
++ (nullable NSString *)unavailableReason
+{
+    NSString *detail = nil;
+    BOOL loaded = MCLoadAccessibilityPlatformTranslation(&detail);
+    return loaded ? nil : (detail ?: @"AccessibilityPlatformTranslation is unavailable");
+}
+
++ (nullable NSDictionary<NSString *, id> *)accessibilityTreeForDevice:(MCSimulatorDevice *)device
+                                                               maxDepth:(NSInteger)maxDepth
+                                                               maxNodes:(NSInteger)maxNodes
+                                                         requestTimeout:(NSTimeInterval)requestTimeout
+                                                                  error:(NSError **)error
+{
+    NSString *loadFailure = nil;
+    if (!MCLoadAccessibilityPlatformTranslation(&loadFailure)) {
+        if (error != NULL) {
+            *error = MCAccessibilityError(MCAccessibilityErrorFrameworkUnavailable,
+                                           loadFailure ?: @"AccessibilityPlatformTranslation could not be loaded",
+                                           nil);
+        }
+        return nil;
+    }
+
+    Class<MCAXPTranslatorClass> translatorClass = (Class<MCAXPTranslatorClass>)NSClassFromString(@"AXPTranslator");
+    if (translatorClass == nil || ![translatorClass respondsToSelector:@selector(sharedInstance)]) {
+        if (error != NULL) {
+            *error = MCAccessibilityError(MCAccessibilityErrorSelectorUnavailable,
+                                           @"AXPTranslator.sharedInstance is not available in this process", nil);
+        }
+        return nil;
+    }
+
+    id rawDevice = device.device;
+    if (![rawDevice respondsToSelector:@selector(sendAccessibilityRequestAsync:completionQueue:completionHandler:)]) {
+        if (error != NULL) {
+            *error = MCAccessibilityError(
+                MCAccessibilityErrorSelectorUnavailable,
+                @"This CoreSimulator does not expose sendAccessibilityRequestAsync:; Xcode 12 or later is required",
+                nil);
+        }
+        return nil;
+    }
+
+    @try {
+        id<MCAXPTranslator> translator = (id<MCAXPTranslator>)[translatorClass sharedInstance];
+        if (translator == nil) {
+            if (error != NULL) {
+                *error = MCAccessibilityError(MCAccessibilityErrorSelectorUnavailable,
+                                               @"AXPTranslator.sharedInstance returned nil", nil);
+            }
+            return nil;
+        }
+
+        MCAXTranslationDelegate *delegate = [MCAXTranslationDelegate sharedDelegate];
+        NSString *token = [delegate registerDevice:rawDevice timeout:MAX(requestTimeout, 0.1)];
+
+        @try {
+            [translator setBridgeTokenDelegate:delegate];
+            id application = [translator frontmostApplicationWithDisplayId:0 bridgeDelegateToken:token];
+            id root = application != nil ? [translator macPlatformElementFromTranslation:application] : nil;
+
+            if (root == nil || ![root isKindOfClass:NSObject.class]) {
+                if (error != NULL) {
+                    if ([delegate didTimeOutForToken:token]) {
+                        *error = MCAccessibilityError(
+                            MCAccessibilityErrorTimeout,
+                            [NSString stringWithFormat:
+                                          @"Timed out waiting %.1fs for the simulator's accessibility translation",
+                                          requestTimeout],
+                            nil);
+                    } else if ([delegate didRequestFailForToken:token]) {
+                        *error = MCAccessibilityError(
+                            MCAccessibilityErrorInternal,
+                            @"The simulator rejected an accessibility translation request", nil);
+                    } else {
+                        *error = MCAccessibilityError(MCAccessibilityErrorEmptyTree,
+                                                       @"The simulator reported no frontmost application", nil);
+                    }
+                }
+                return nil;
+            }
+
+            NSDictionary<NSString *, id> *tree =
+                MCAccessibilityNodeForElement((id<NSAccessibility>)root, maxDepth, maxNodes);
+
+            if ([delegate didTimeOutForToken:token]) {
+                if (error != NULL) {
+                    *error = MCAccessibilityError(
+                        MCAccessibilityErrorTimeout,
+                        [NSString stringWithFormat:
+                                      @"Timed out waiting %.1fs for the simulator's accessibility translation",
+                                      requestTimeout],
+                        nil);
+                }
+                return nil;
+            }
+            if ([delegate didRequestFailForToken:token]) {
+                if (error != NULL) {
+                    *error = MCAccessibilityError(
+                        MCAccessibilityErrorInternal,
+                        @"The simulator rejected an accessibility translation request", nil);
+                }
+                return nil;
+            }
+            if (tree == nil) {
+                if (error != NULL) {
+                    *error = MCAccessibilityError(
+                        MCAccessibilityErrorEmptyTree,
+                        @"The frontmost application reported no readable accessibility attributes", nil);
+                }
+                return nil;
+            }
+            return tree;
+        } @finally {
+            [delegate unregisterToken:token];
+        }
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            *error = MCAccessibilityError(
+                MCAccessibilityErrorInternal,
+                [NSString stringWithFormat:@"Reading the accessibility tree raised %@: %@", exception.name,
+                                            exception.reason ?: @"no reason"],
+                nil);
+        }
+        return nil;
+    }
+}
+
+@end

--- a/native/mobile-screencap/Sources/SimulatorDeviceBridge.h
+++ b/native/mobile-screencap/Sources/SimulatorDeviceBridge.h
@@ -24,6 +24,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// The main screen scale, or `0` when CoreSimulator did not report one.
 @property (nonatomic, readonly) float mainScreenScale;
 
+/// Whether CoreSimulator reports this device as booted. Read defensively: a device that raises
+/// while answering (or an unexpectedly old CoreSimulator) is treated as not booted rather than
+/// letting the exception escape.
+@property (nonatomic, readonly, getter=isBooted) BOOL booted;
+
+/// CoreSimulator's own state name (`"Booted"`, `"Shutdown"`, ...), or `nil` when it could not be
+/// read.
+@property (nonatomic, readonly, copy, nullable) NSString *stateDescription;
+
 /// Whether the CoreSimulator private framework could be loaded in this process.
 @property (class, nonatomic, readonly, getter=isCoreSimulatorAvailable) BOOL coreSimulatorAvailable;
 

--- a/native/mobile-screencap/Sources/SimulatorDeviceBridge.m
+++ b/native/mobile-screencap/Sources/SimulatorDeviceBridge.m
@@ -181,4 +181,33 @@ static BOOL MCLoadCoreSimulatorFramework(void)
     }
 }
 
+- (nullable NSString *)stateDescription
+{
+    @try {
+        NSString *description = [(SimDevice *)self.device stateString];
+        return [description isKindOfClass:NSString.class] ? description : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+- (BOOL)isBooted
+{
+    NSString *stateDescription = self.stateDescription;
+    if (stateDescription != nil &&
+        [stateDescription caseInsensitiveCompare:@"Booted"] == NSOrderedSame) {
+        return YES;
+    }
+    // `stateString` is preferred, but fall back to the raw enum (`3` is `SimDeviceStateBooted`) in
+    // case a future CoreSimulator ever stops answering `stateString`.
+    if (stateDescription == nil) {
+        @try {
+            return [(SimDevice *)self.device state] == 3;
+        } @catch (__unused NSException *exception) {
+            return NO;
+        }
+    }
+    return NO;
+}
+
 @end

--- a/native/mobile-screencap/Sources/SimulatorPrivateAPI.h
+++ b/native/mobile-screencap/Sources/SimulatorPrivateAPI.h
@@ -1,5 +1,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
 #import <mach/mach.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -31,7 +32,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSUUID *UDID;
 @property (nonatomic, readonly) id io;
 @property (nonatomic, readonly) SimDeviceType *deviceType;
+/// `SimDeviceState` as a raw integer (`3` is `Booted`); read defensively, see `stateString`.
+@property (nonatomic, readonly) unsigned long long state;
+/// CoreSimulator's own human-readable state name (`"Booted"`, `"Shutdown"`, ...), preferred over
+/// `state` because it does not depend on the numeric enum staying stable across CoreSimulator
+/// versions.
+@property (nonatomic, readonly, copy) NSString *stateString;
 - (mach_port_t)lookup:(NSString *)service error:(NSError **)error;
+/// Bridges a translated accessibility request to the guest and back. Only present on CoreSimulator
+/// builds that ship the host-side accessibility-translation path (Xcode 12+); callers must guard
+/// with `respondsToSelector:` before sending this. `request`/the value handed to `completionHandler`
+/// are opaque `AXPTranslatorRequest`/`AXPTranslatorResponse` instances from the
+/// `AccessibilityPlatformTranslation` framework -- declared as `id` here so this header never needs
+/// to name (and thus never needs to link) that framework.
+- (void)sendAccessibilityRequestAsync:(id)request
+                       completionQueue:(dispatch_queue_t)completionQueue
+                     completionHandler:(void (^)(id _Nullable response))completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/native/mobile-screencap/Tests/AccessibilityTestSupport.h
+++ b/native/mobile-screencap/Tests/AccessibilityTestSupport.h
@@ -9,8 +9,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// unset (`nil` for objects, the `has*` flag left `NO` for scalars) reproduces an element that does
 /// not respond to that selector, exactly like a real `AXPMacPlatformElement` that has nothing to say
 /// for a given attribute.
+@interface MCFakeAXTranslation : NSObject
+
+@property (nonatomic, copy, nullable) NSString *bridgeDelegateToken;
+
+@end
+
 @interface MCFakeAXElement : NSObject
 
+@property (nonatomic, strong) MCFakeAXTranslation *translation;
+@property (nonatomic, copy, nullable) NSString *expectedBridgeDelegateToken;
 @property (nonatomic, copy, nullable) NSString *fakeRole;
 @property (nonatomic, copy, nullable) NSString *fakeSubrole;
 @property (nonatomic, copy, nullable) NSString *fakeLabel;

--- a/native/mobile-screencap/Tests/AccessibilityTestSupport.h
+++ b/native/mobile-screencap/Tests/AccessibilityTestSupport.h
@@ -1,0 +1,32 @@
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A settable stand-in for a translated `NSAccessibility` element, so `MCAccessibilityNodeForElement`
+/// can be exercised deterministically without a booted simulator or the private translation
+/// framework. Every property mirrors one of the selectors the real bridge reads; leaving a property
+/// unset (`nil` for objects, the `has*` flag left `NO` for scalars) reproduces an element that does
+/// not respond to that selector, exactly like a real `AXPMacPlatformElement` that has nothing to say
+/// for a given attribute.
+@interface MCFakeAXElement : NSObject
+
+@property (nonatomic, copy, nullable) NSString *fakeRole;
+@property (nonatomic, copy, nullable) NSString *fakeSubrole;
+@property (nonatomic, copy, nullable) NSString *fakeLabel;
+@property (nonatomic, copy, nullable) NSString *fakeIdentifier;
+@property (nonatomic, copy, nullable) NSString *fakeHelp;
+@property (nonatomic, nullable) id fakeValue;
+@property (nonatomic) BOOL hasFakeValue;
+@property (nonatomic) NSRect fakeFrame;
+@property (nonatomic) BOOL hasFakeFrame;
+@property (nonatomic) BOOL fakeEnabled;
+@property (nonatomic) BOOL hasFakeEnabled;
+@property (nonatomic) BOOL fakeFocused;
+@property (nonatomic) BOOL hasFakeFocused;
+@property (nonatomic, copy) NSArray<MCFakeAXElement *> *fakeChildren;
+@property (nonatomic) BOOL hasFakeChildren;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/native/mobile-screencap/Tests/AccessibilityTestSupport.m
+++ b/native/mobile-screencap/Tests/AccessibilityTestSupport.m
@@ -1,0 +1,87 @@
+#import "AccessibilityTestSupport.h"
+
+@implementation MCFakeAXElement
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self != nil) {
+        _fakeChildren = @[];
+    }
+    return self;
+}
+
+// Only "responds" to the bounded/typed selectors when the matching test explicitly set a value,
+// so a test can reproduce a real `AXPMacPlatformElement` that simply has nothing to say for a
+// given attribute (the bridge always checks `respondsToSelector:` first).
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if (aSelector == @selector(accessibilityValue)) {
+        return self.hasFakeValue;
+    }
+    if (aSelector == @selector(accessibilityFrame)) {
+        return self.hasFakeFrame;
+    }
+    if (aSelector == @selector(isAccessibilityEnabled)) {
+        return self.hasFakeEnabled;
+    }
+    if (aSelector == @selector(isAccessibilityFocused)) {
+        return self.hasFakeFocused;
+    }
+    if (aSelector == @selector(accessibilityChildren)) {
+        return self.hasFakeChildren;
+    }
+    return [super respondsToSelector:aSelector];
+}
+
+- (nullable NSString *)accessibilityRole
+{
+    return self.fakeRole;
+}
+
+- (nullable NSString *)accessibilitySubrole
+{
+    return self.fakeSubrole;
+}
+
+- (nullable NSString *)accessibilityLabel
+{
+    return self.fakeLabel;
+}
+
+- (nullable NSString *)accessibilityIdentifier
+{
+    return self.fakeIdentifier;
+}
+
+- (nullable NSString *)accessibilityHelp
+{
+    return self.fakeHelp;
+}
+
+- (nullable id)accessibilityValue
+{
+    return self.fakeValue;
+}
+
+- (NSRect)accessibilityFrame
+{
+    return self.fakeFrame;
+}
+
+- (BOOL)isAccessibilityEnabled
+{
+    return self.fakeEnabled;
+}
+
+- (BOOL)isAccessibilityFocused
+{
+    return self.fakeFocused;
+}
+
+- (NSArray<MCFakeAXElement *> *)accessibilityChildren
+{
+    return self.fakeChildren;
+}
+
+@end

--- a/native/mobile-screencap/Tests/AccessibilityTestSupport.m
+++ b/native/mobile-screencap/Tests/AccessibilityTestSupport.m
@@ -1,14 +1,27 @@
 #import "AccessibilityTestSupport.h"
 
+@implementation MCFakeAXTranslation
+@end
+
 @implementation MCFakeAXElement
 
 - (instancetype)init
 {
     self = [super init];
     if (self != nil) {
+        _translation = [[MCFakeAXTranslation alloc] init];
         _fakeChildren = @[];
     }
     return self;
+}
+
+- (void)requireExpectedBridgeDelegateToken
+{
+    if (self.expectedBridgeDelegateToken != nil &&
+        ![self.translation.bridgeDelegateToken isEqualToString:self.expectedBridgeDelegateToken]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Accessibility attribute read before bridge token propagation"];
+    }
 }
 
 // Only "responds" to the bounded/typed selectors when the matching test explicitly set a value,
@@ -36,6 +49,7 @@
 
 - (nullable NSString *)accessibilityRole
 {
+    [self requireExpectedBridgeDelegateToken];
     return self.fakeRole;
 }
 
@@ -81,6 +95,7 @@
 
 - (NSArray<MCFakeAXElement *> *)accessibilityChildren
 {
+    [self requireExpectedBridgeDelegateToken];
     return self.fakeChildren;
 }
 

--- a/native/mobile-screencap/Tests/AccessibilityTests.swift
+++ b/native/mobile-screencap/Tests/AccessibilityTests.swift
@@ -9,6 +9,7 @@ import Foundation
 enum AccessibilityTests {
 	static func run(_ runner: TestRunner) {
 		serialization(runner)
+		bridgeDelegateTokenPropagation(runner)
 		valueConversion(runner)
 		optionalAttributes(runner)
 		traversalBounds(runner)
@@ -92,6 +93,33 @@ enum AccessibilityTests {
 			runner.expect(node["role"] == nil, "role is omitted, not empty-stringed")
 			runner.expect(node["AXLabel"] == nil, "AXLabel is omitted")
 			runner.expect((node["children"] as? [Any])?.isEmpty == true, "children is still an empty array")
+		}
+	}
+
+	// MARK: Bridge delegate token
+
+	static func bridgeDelegateTokenPropagation(_ runner: TestRunner) {
+		runner.test("bridge token reaches the root and children before attribute reads") {
+			let token = "test-token"
+			let child = MCFakeAXElement()
+			child.fakeRole = "AXButton"
+			child.expectedBridgeDelegateToken = token
+
+			let root = MCFakeAXElement()
+			root.fakeRole = "AXWindow"
+			root.fakeChildren = [child]
+			root.hasFakeChildren = true
+			root.expectedBridgeDelegateToken = token
+
+			let node = MCAccessibilityNodeForElementWithBridgeDelegateToken(root, 64, 20_000, token)
+
+			runner.expectEqual(node?["role"] as? String, "AXWindow", "root role")
+			runner.expectEqual(
+				(node?["children"] as? [[String: Any]])?.first?["role"] as? String,
+				"AXButton",
+				"child role")
+			runner.expectEqual(root.translation.bridgeDelegateToken, token, "root bridge token")
+			runner.expectEqual(child.translation.bridgeDelegateToken, token, "child bridge token")
 		}
 	}
 

--- a/native/mobile-screencap/Tests/AccessibilityTests.swift
+++ b/native/mobile-screencap/Tests/AccessibilityTests.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+/// Coverage for the accessibility reader's pure, simulator-independent pieces: the
+/// `MCAccessibilityNodeForElement` serialization/bounding contract (fed a fake `NSAccessibility`
+/// element tree, so no booted simulator or private framework is required) and
+/// `AccessibilityCommand`'s error-code mapping and clamp helpers. Live delivery against a real
+/// translated tree is only provable against a booted device and is exercised manually, plus by the
+/// shipped-helper contract check in `test.sh` for the "device does not exist" failure path.
+enum AccessibilityTests {
+	static func run(_ runner: TestRunner) {
+		serialization(runner)
+		valueConversion(runner)
+		optionalAttributes(runner)
+		traversalBounds(runner)
+		commandHelpers(runner)
+	}
+
+	// MARK: Serialization
+
+	static func serialization(_ runner: TestRunner) {
+		runner.test("a fully populated leaf serializes every managed-compatible key") {
+			let element = MCFakeAXElement()
+			element.fakeRole = "AXButton"
+			element.fakeSubrole = "AXCloseButton"
+			element.fakeLabel = "Done"
+			element.fakeIdentifier = "done-button"
+			element.fakeHelp = "Dismisses the sheet"
+			element.fakeValue = "1"
+			element.hasFakeValue = true
+			element.fakeFrame = NSRect(x: 1, y: 2, width: 3, height: 4)
+			element.hasFakeFrame = true
+			element.fakeEnabled = true
+			element.hasFakeEnabled = true
+			element.fakeFocused = true
+			element.hasFakeFocused = true
+
+			guard let node = MCAccessibilityNodeForElement(element, 64, 20000) else {
+				runner.expect(false, "expected a node for a fully populated element")
+				return
+			}
+
+			runner.expectEqual(node["role"] as? String, "AXButton", "role keeps the AX prefix")
+			runner.expectEqual(node["type"] as? String, "Button", "type strips the AX prefix")
+			runner.expectEqual(node["subrole"] as? String, "AXCloseButton", "subrole")
+			runner.expectEqual(node["AXLabel"] as? String, "Done", "AXLabel")
+			runner.expectEqual(node["AXValue"] as? String, "1", "AXValue")
+			runner.expectEqual(node["AXUniqueId"] as? String, "done-button", "AXUniqueId")
+			runner.expectEqual(node["help"] as? String, "Dismisses the sheet", "help")
+			runner.expectEqual(node["enabled"] as? Bool, true, "enabled")
+			runner.expectEqual(node["focused"] as? Bool, true, "focused")
+
+			guard let frame = node["frame"] as? [String: Any] else {
+				runner.expect(false, "expected a frame dictionary")
+				return
+			}
+			runner.expectClose((frame["x"] as? NSNumber)?.doubleValue ?? -1, 1, "frame.x")
+			runner.expectClose((frame["y"] as? NSNumber)?.doubleValue ?? -1, 2, "frame.y")
+			runner.expectClose((frame["width"] as? NSNumber)?.doubleValue ?? -1, 3, "frame.width")
+			runner.expectClose((frame["height"] as? NSNumber)?.doubleValue ?? -1, 4, "frame.height")
+
+			runner.expect((node["children"] as? [Any])?.isEmpty == true, "children defaults to an empty array")
+		}
+
+		runner.test("role normalization leaves a role without the AX prefix untouched") {
+			let element = MCFakeAXElement()
+			element.fakeRole = "Button"
+			guard let node = MCAccessibilityNodeForElement(element, 64, 20000) else {
+				runner.expect(false, "expected a node")
+				return
+			}
+			runner.expectEqual(node["role"] as? String, "Button", "role")
+			runner.expectEqual(node["type"] as? String, "Button", "type is unchanged without an AX prefix")
+		}
+
+		runner.test("a two-character role is left alone rather than emptied") {
+			let element = MCFakeAXElement()
+			element.fakeRole = "AX"
+			guard let node = MCAccessibilityNodeForElement(element, 64, 20000) else {
+				runner.expect(false, "expected a node")
+				return
+			}
+			runner.expectEqual(node["role"] as? String, "AX", "role")
+			runner.expectEqual(node["type"] as? String, "AX", "a bare 'AX' has nothing to strip")
+		}
+
+		runner.test("an element with nothing set still serializes with an empty children array") {
+			let element = MCFakeAXElement()
+			guard let node = MCAccessibilityNodeForElement(element, 64, 20000) else {
+				runner.expect(false, "expected a node even for an empty element")
+				return
+			}
+			runner.expect(node["role"] == nil, "role is omitted, not empty-stringed")
+			runner.expect(node["AXLabel"] == nil, "AXLabel is omitted")
+			runner.expect((node["children"] as? [Any])?.isEmpty == true, "children is still an empty array")
+		}
+	}
+
+	// MARK: AXValue conversion
+
+	static func valueConversion(_ runner: TestRunner) {
+		runner.test("AXValue passes strings and numbers through unchanged") {
+			let stringElement = MCFakeAXElement()
+			stringElement.fakeValue = "hello"
+			stringElement.hasFakeValue = true
+			let stringNode = MCAccessibilityNodeForElement(stringElement, 64, 20000)
+			runner.expectEqual(stringNode?["AXValue"] as? String, "hello", "string value")
+
+			let numberElement = MCFakeAXElement()
+			numberElement.fakeValue = NSNumber(value: 0.5)
+			numberElement.hasFakeValue = true
+			let numberNode = MCAccessibilityNodeForElement(numberElement, 64, 20000)
+			runner.expectClose(
+				(numberNode?["AXValue"] as? NSNumber)?.doubleValue ?? -1, 0.5, "number value passes through")
+		}
+
+		runner.test("AXValue degrades an arbitrary object to its description") {
+			let element = MCFakeAXElement()
+			element.fakeValue = NSDate(timeIntervalSinceReferenceDate: 0)
+			element.hasFakeValue = true
+			let node = MCAccessibilityNodeForElement(element, 64, 20000)
+			runner.expect(node?["AXValue"] is String, "a non-JSON-native value becomes a description string")
+		}
+
+		runner.test("AXValue is omitted for nil, NSNull, or when the selector is unavailable") {
+			let nilElement = MCFakeAXElement()
+			nilElement.hasFakeValue = true
+			nilElement.fakeValue = nil
+			runner.expect(
+				MCAccessibilityNodeForElement(nilElement, 64, 20000)?["AXValue"] == nil,
+				"nil value is omitted")
+
+			let nullElement = MCFakeAXElement()
+			nullElement.hasFakeValue = true
+			nullElement.fakeValue = NSNull()
+			runner.expect(
+				MCAccessibilityNodeForElement(nullElement, 64, 20000)?["AXValue"] == nil,
+				"NSNull value is omitted")
+
+			let unavailableElement = MCFakeAXElement()
+			unavailableElement.hasFakeValue = false
+			runner.expect(
+				MCAccessibilityNodeForElement(unavailableElement, 64, 20000)?["AXValue"] == nil,
+				"an unimplemented selector is omitted, not defaulted")
+		}
+	}
+
+	// MARK: enabled/focused/frame omission
+
+	static func optionalAttributes(_ runner: TestRunner) {
+		runner.test("enabled and focused are omitted, not defaulted, when unavailable") {
+			let element = MCFakeAXElement()
+			// hasFakeEnabled/hasFakeFocused default to false, so the fake does not "respond" to
+			// either selector -- exactly like a real element with nothing to say for them. The
+			// managed AccessibilityParser is the one responsible for defaulting a missing
+			// `enabled` to true and a missing `focused` to false, not the native reader.
+			guard let node = MCAccessibilityNodeForElement(element, 64, 20000) else {
+				runner.expect(false, "expected a node")
+				return
+			}
+			runner.expect(node["enabled"] == nil, "enabled key is absent, not false")
+			runner.expect(node["focused"] == nil, "focused key is absent, not false")
+		}
+
+		runner.test("frame is omitted entirely when the selector is unavailable") {
+			let element = MCFakeAXElement()
+			element.hasFakeFrame = false
+			let node = MCAccessibilityNodeForElement(element, 64, 20000)
+			runner.expect(node?["frame"] == nil, "frame key is absent when accessibilityFrame is unavailable")
+		}
+	}
+
+	// MARK: Traversal bounds
+
+	static func traversalBounds(_ runner: TestRunner) {
+		runner.test("maxDepth 0 keeps only the root, with an empty children array") {
+			let child = MCFakeAXElement()
+			child.fakeRole = "AXStaticText"
+			let root = MCFakeAXElement()
+			root.fakeRole = "AXWindow"
+			root.fakeChildren = [child]
+			root.hasFakeChildren = true
+
+			guard let node = MCAccessibilityNodeForElement(root, 0, 20000) else {
+				runner.expect(false, "expected a root node")
+				return
+			}
+			runner.expectEqual(node["role"] as? String, "AXWindow", "root role is still present")
+			runner.expect((node["children"] as? [Any])?.isEmpty == true, "depth 0 truncates all children")
+		}
+
+		runner.test("maxDepth 1 includes direct children but not grandchildren") {
+			let grandchild = MCFakeAXElement()
+			grandchild.fakeRole = "AXStaticText"
+			let child = MCFakeAXElement()
+			child.fakeRole = "AXGroup"
+			child.fakeChildren = [grandchild]
+			child.hasFakeChildren = true
+			let root = MCFakeAXElement()
+			root.fakeRole = "AXWindow"
+			root.fakeChildren = [child]
+			root.hasFakeChildren = true
+
+			guard let node = MCAccessibilityNodeForElement(root, 1, 20000) else {
+				runner.expect(false, "expected a root node")
+				return
+			}
+			guard let children = node["children"] as? [[String: Any]], children.count == 1 else {
+				runner.expect(false, "expected exactly one direct child")
+				return
+			}
+			runner.expectEqual(children[0]["role"] as? String, "AXGroup", "direct child role")
+			runner.expect(
+				(children[0]["children"] as? [Any])?.isEmpty == true,
+				"grandchildren are cut off at maxDepth 1")
+		}
+
+		runner.test("a non-NSAccessibility child is skipped rather than crashing the walk") {
+			// MCAXChildren only accepts an NSArray back from accessibilityChildren; the bridge
+			// itself additionally guards each entry with -isKindOfClass:NSObject.class before
+			// recursing, so a well-formed array of real elements never produces a gap. This test
+			// pins down that a normally-shaped, all-valid children array round-trips in full.
+			let first = MCFakeAXElement()
+			first.fakeRole = "AXStaticText"
+			let second = MCFakeAXElement()
+			second.fakeRole = "AXButton"
+			let root = MCFakeAXElement()
+			root.fakeChildren = [first, second]
+			root.hasFakeChildren = true
+
+			guard let node = MCAccessibilityNodeForElement(root, 64, 20000) else {
+				runner.expect(false, "expected a root node")
+				return
+			}
+			runner.expectEqual((node["children"] as? [Any])?.count, 2, "both valid children are kept")
+		}
+
+		runner.test("maxNodes bounds the total node count across the whole tree, root included") {
+			let children = (0..<5).map { index -> MCFakeAXElement in
+				let element = MCFakeAXElement()
+				element.fakeRole = "AXStaticText"
+				element.fakeIdentifier = "child-\(index)"
+				return element
+			}
+			let root = MCFakeAXElement()
+			root.fakeRole = "AXWindow"
+			root.fakeChildren = children
+			root.hasFakeChildren = true
+
+			// Budget of 3 covers the root plus 2 children; the rest are silently dropped, never
+			// an error and never a half-built entry.
+			guard let node = MCAccessibilityNodeForElement(root, 64, 3) else {
+				runner.expect(false, "expected a root node even though the budget is tight")
+				return
+			}
+			runner.expectEqual((node["children"] as? [Any])?.count, 2, "only 2 of 5 children fit the budget")
+		}
+
+		runner.test("maxNodes of 1 keeps only the root and reports no children") {
+			let child = MCFakeAXElement()
+			let root = MCFakeAXElement()
+			root.fakeChildren = [child]
+			root.hasFakeChildren = true
+
+			guard let node = MCAccessibilityNodeForElement(root, 64, 1) else {
+				runner.expect(false, "expected a root node")
+				return
+			}
+			runner.expect((node["children"] as? [Any])?.isEmpty == true, "a budget of 1 leaves no room for children")
+		}
+
+		runner.test("a non-positive maxNodes still yields a root rather than nil") {
+			// The wrapper clamps an adversarial/zero budget up to 1 so a caller always gets a
+			// well-formed (if minimal) tree instead of an empty response for a bad argument.
+			let root = MCFakeAXElement()
+			root.fakeRole = "AXWindow"
+			let node = MCAccessibilityNodeForElement(root, 64, 0)
+			runner.expect(node != nil, "maxNodes <= 0 is clamped up to at least 1")
+			runner.expectEqual(node?["role"] as? String, "AXWindow", "the clamped root is still fully serialized")
+		}
+	}
+
+	// MARK: AccessibilityCommand helpers
+
+	static func commandHelpers(_ runner: TestRunner) {
+		runner.test("errorCode(forRawValue:) maps every MCAccessibilityErrorCode to a stable string") {
+			runner.expectEqual(
+				AccessibilityCommand.errorCode(forRawValue: 1), "framework_unavailable", "FrameworkUnavailable")
+			runner.expectEqual(
+				AccessibilityCommand.errorCode(forRawValue: 2), "selector_unavailable", "SelectorUnavailable")
+			runner.expectEqual(
+				AccessibilityCommand.errorCode(forRawValue: 3), "device_not_booted", "DeviceNotBooted")
+			runner.expectEqual(AccessibilityCommand.errorCode(forRawValue: 4), "timeout", "Timeout")
+			runner.expectEqual(AccessibilityCommand.errorCode(forRawValue: 5), "empty_tree", "EmptyTree")
+			runner.expectEqual(AccessibilityCommand.errorCode(forRawValue: 6), "internal_error", "Internal")
+			runner.expectEqual(
+				AccessibilityCommand.errorCode(forRawValue: 0), "internal_error", "an unknown code falls back safely")
+			runner.expectEqual(
+				AccessibilityCommand.errorCode(forRawValue: 999), "internal_error",
+				"an out-of-range code falls back safely")
+		}
+
+		runner.test("clampInt keeps a value in range and clamps outside it") {
+			runner.expectEqual(AccessibilityCommand.clampInt(10, min: 0, max: 100), 10, "in range")
+			runner.expectEqual(AccessibilityCommand.clampInt(-5, min: 0, max: 100), 0, "below the floor")
+			runner.expectEqual(AccessibilityCommand.clampInt(500, min: 0, max: 100), 100, "above the ceiling")
+			runner.expectEqual(
+				AccessibilityCommand.clampInt(0, min: 0, max: 4096), 0, "maxDepth of 0 (root only) is legal")
+		}
+
+		runner.test("clampTimeout keeps a sane request timeout") {
+			runner.expectClose(AccessibilityCommand.clampTimeout(2.5), 2.5, "in range")
+			runner.expectClose(AccessibilityCommand.clampTimeout(0), 0.1, "a zero/negative timeout floors to 0.1s")
+			runner.expectClose(AccessibilityCommand.clampTimeout(-5), 0.1, "a negative timeout floors to 0.1s")
+			runner.expectClose(AccessibilityCommand.clampTimeout(120), 60, "an excessive timeout ceilings to 60s")
+			runner.expectClose(
+				AccessibilityCommand.clampTimeout(.infinity), AccessibilityCommand.defaultRequestTimeout,
+				"a non-finite timeout falls back to the default")
+			runner.expectClose(
+				AccessibilityCommand.clampTimeout(.nan), AccessibilityCommand.defaultRequestTimeout,
+				"NaN falls back to the default")
+		}
+	}
+}

--- a/native/mobile-screencap/Tests/HidCommandTestSupport.swift
+++ b/native/mobile-screencap/Tests/HidCommandTestSupport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// HidCommand is compiled into the native test target without Entry.swift (which owns @main).
-// These minimal test-only definitions satisfy the two command-shell dependencies.
+// HidCommand and AccessibilityCommand are compiled into the native test target without Entry.swift
+// (which owns @main). These minimal test-only definitions satisfy their command-shell dependencies.
 struct HelperError: Error {
 	init(_: String) {}
 }
@@ -15,6 +15,14 @@ struct CommandLineOptions {
 
 	func string(_ key: String) -> String? {
 		values[key]
+	}
+
+	func int(_ key: String) -> Int? {
+		values[key].flatMap(Int.init)
+	}
+
+	func double(_ key: String) -> Double? {
+		values[key].flatMap(Double.init)
 	}
 }
 

--- a/native/mobile-screencap/Tests/HidTests.swift
+++ b/native/mobile-screencap/Tests/HidTests.swift
@@ -65,6 +65,7 @@ struct HidTests {
 		protocolSerialization(runner)
 		commandFramingAndFailurePolicy(runner)
 		contactCleanup(runner)
+		AccessibilityTests.run(runner)
 
 		runner.finish()
 	}

--- a/native/mobile-screencap/Tests/TestBridging.h
+++ b/native/mobile-screencap/Tests/TestBridging.h
@@ -5,4 +5,6 @@
 #import "SimulatorDeviceBridge.h"
 #import "SimulatorIndigoHid.h"
 #import "SimulatorDtuHid.h"
+#import "SimulatorAccessibilityBridge.h"
 #import "IndigoTestSupport.h"
+#import "AccessibilityTestSupport.h"

--- a/native/mobile-screencap/test.sh
+++ b/native/mobile-screencap/test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Builds and runs the native mobile-screencap HID tests.
+# Builds and runs the native mobile-screencap HID and accessibility tests.
 #
-# The tests link the HID sources plus test-only fakes into their own executable, so nothing under
-# Tests/ is ever compiled into the shipped `mobile-screencap`. They cover the private-API-adjacent
-# logic that can be exercised without a booted simulator: transport selection, framework layout,
-# Indigo wire layout and allocator ownership, DTUHID envelope types, contact tracking, and the
-# NDJSON protocol. Live delivery is only provable against a booted device.
+# The tests link the HID and accessibility sources plus test-only fakes into their own executable,
+# so nothing under Tests/ is ever compiled into the shipped `mobile-screencap`. They cover the
+# private-API-adjacent logic that can be exercised without a booted simulator: transport selection,
+# framework layout, Indigo wire layout and allocator ownership, DTUHID envelope types, contact
+# tracking, the NDJSON protocol, and the accessibility reader's serialization/traversal bounds
+# (fed a fake NSAccessibility element tree). Live delivery is only provable against a booted device.
 #
 # Usage:
 #   ./test.sh                 # host architecture
@@ -53,14 +54,18 @@ SWIFT_SOURCES=(
 	"$SCRIPT_DIR/Sources/HidCommand.swift"
 	"$SCRIPT_DIR/Sources/HidProtocol.swift"
 	"$SCRIPT_DIR/Sources/HidSession.swift"
+	"$SCRIPT_DIR/Sources/AccessibilityCommand.swift"
 	"$SCRIPT_DIR/Tests/HidCommandTestSupport.swift"
+	"$SCRIPT_DIR/Tests/AccessibilityTests.swift"
 	"$SCRIPT_DIR/Tests/HidTests.swift"
 )
 OBJC_SOURCES=(
 	"$SCRIPT_DIR/Sources/SimulatorDeviceBridge.m"
 	"$SCRIPT_DIR/Sources/SimulatorIndigoHid.m"
 	"$SCRIPT_DIR/Sources/SimulatorDtuHid.m"
+	"$SCRIPT_DIR/Sources/SimulatorAccessibilityBridge.m"
 	"$SCRIPT_DIR/Tests/IndigoTestSupport.m"
+	"$SCRIPT_DIR/Tests/AccessibilityTestSupport.m"
 )
 
 echo "building native HID tests for $ARCH..."
@@ -148,6 +153,34 @@ PY
 		exit 1
 	}
 	printf '' | "$HELPER" encode --width 2 --height 2 > /dev/null 2>&1 || true
+
+	# The accessibility reader must fail the same startup-frame way as `hid` for a device that does
+	# not exist -- no protocolVersion field (it never emitted one), but the same
+	# type/code/message/non-zero-exit shape a managed caller already knows how to fall back from.
+	"$HELPER" --help 2>&1 | grep -q "accessibility" || {
+		echo "the helper no longer advertises 'accessibility'" >&2
+		exit 1
+	}
+	set +e
+	"$HELPER" accessibility --udid 00000000-0000-0000-0000-000000000000 \
+		> "$BUILD_DIR/accessibility-unavailable.ndjson" 2> "$BUILD_DIR/accessibility-unavailable.log"
+	status=$?
+	set -e
+	python3 - "$BUILD_DIR/accessibility-unavailable.ndjson" "$status" <<'PY'
+import json, sys
+lines = [line for line in open(sys.argv[1]).read().splitlines() if line.strip()]
+if len(lines) != 1:
+    raise SystemExit(f"expected exactly one frame on stdout, got {len(lines)}")
+frame = json.loads(lines[0])
+if frame.get("type") != "unavailable":
+    raise SystemExit(f"expected an 'unavailable' frame, got {frame!r}")
+if not frame.get("code") or not frame.get("message"):
+    raise SystemExit(f"the frame is missing code/message: {frame!r}")
+if sys.argv[2] == "0":
+    raise SystemExit("a nonexistent device must exit non-zero")
+print("accessibility startup ok")
+PY
+
 	echo "shipped helper commands ok"
 else
 	echo "note: $HELPER is not built; skipping shipped-helper checks" >&2

--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -3,82 +3,82 @@
     "darwin-arm64": {
       "rid": "osx-arm64",
       "executable": "mobile-canvas",
-      "id": "e43d37a222c53a52ff45588159beaa6e265d5b0570c7f2d9152f616cc3ca000a",
+      "id": "9511132796110868eca33d9ad540ef12e01c62fcc138f3192330334cf8ab3e04",
       "files": {
         "mobile-canvas": {
-          "sha256": "e43d37a222c53a52ff45588159beaa6e265d5b0570c7f2d9152f616cc3ca000a",
-          "size": 32244016,
-          "asset": "mobile-canvas-v0.1.17-osx-arm64.gz"
+          "sha256": "9511132796110868eca33d9ad540ef12e01c62fcc138f3192330334cf8ab3e04",
+          "size": 32260640,
+          "asset": "mobile-canvas-v0.1.17-rc.3-osx-arm64.gz"
         },
         "mobile-screencap": {
-          "sha256": "119b2c58958faa985523ab50273600752098856f41a5a2b633ced63037f0e8b7",
-          "size": 911488,
-          "asset": "mobile-screencap-v0.1.17-osx-arm64.gz"
+          "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
+          "size": 969664,
+          "asset": "mobile-screencap-v0.1.17-rc.3-osx-arm64.gz"
         }
       }
     },
     "darwin-x64": {
       "rid": "osx-x64",
       "executable": "mobile-canvas",
-      "id": "3b411807ba3ed49b4530ffb4844521aff56f0cf06eaeef342a7902e538ff4eeb",
+      "id": "e40e190629d10e6272e3465c74dcbd65b4c296e64438c47473b32a7f3b5104a2",
       "files": {
         "mobile-canvas": {
-          "sha256": "3b411807ba3ed49b4530ffb4844521aff56f0cf06eaeef342a7902e538ff4eeb",
-          "size": 33991760,
-          "asset": "mobile-canvas-v0.1.17-osx-x64.gz"
+          "sha256": "e40e190629d10e6272e3465c74dcbd65b4c296e64438c47473b32a7f3b5104a2",
+          "size": 34008240,
+          "asset": "mobile-canvas-v0.1.17-rc.3-osx-x64.gz"
         },
         "mobile-screencap": {
-          "sha256": "119b2c58958faa985523ab50273600752098856f41a5a2b633ced63037f0e8b7",
-          "size": 911488,
-          "asset": "mobile-screencap-v0.1.17-osx-x64.gz"
+          "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
+          "size": 969664,
+          "asset": "mobile-screencap-v0.1.17-rc.3-osx-x64.gz"
         }
       }
     },
     "linux-arm64": {
       "rid": "linux-arm64",
       "executable": "mobile-canvas",
-      "id": "88c781bf99c2aafa8e0d02fc5c627ec67d5b3c2975201778dc8356e0889ed422",
+      "id": "1b3b7f913b796fa217738ff714c1c979ddead9db0a4b04e793c2da6ac2fb669a",
       "files": {
         "mobile-canvas": {
-          "sha256": "88c781bf99c2aafa8e0d02fc5c627ec67d5b3c2975201778dc8356e0889ed422",
-          "size": 34351360,
-          "asset": "mobile-canvas-v0.1.17-linux-arm64.gz"
+          "sha256": "1b3b7f913b796fa217738ff714c1c979ddead9db0a4b04e793c2da6ac2fb669a",
+          "size": 34417304,
+          "asset": "mobile-canvas-v0.1.17-rc.3-linux-arm64.gz"
         }
       }
     },
     "linux-x64": {
       "rid": "linux-x64",
       "executable": "mobile-canvas",
-      "id": "03b833d60645f14bb13afc13c95c71a03510ed1f4c32d4400ab06bae77b7ba2e",
+      "id": "ebde13fcd38f071a162fec9a729cab1ea0c2265ffbe447f96467a781c3841828",
       "files": {
         "mobile-canvas": {
-          "sha256": "03b833d60645f14bb13afc13c95c71a03510ed1f4c32d4400ab06bae77b7ba2e",
-          "size": 33654816,
-          "asset": "mobile-canvas-v0.1.17-linux-x64.gz"
+          "sha256": "ebde13fcd38f071a162fec9a729cab1ea0c2265ffbe447f96467a781c3841828",
+          "size": 33671616,
+          "asset": "mobile-canvas-v0.1.17-rc.3-linux-x64.gz"
         }
       }
     },
     "win32-arm64": {
       "rid": "win-arm64",
       "executable": "mobile-canvas.exe",
-      "id": "a27e8feac4b03acfeff374547152cff7fc8d4f8e5feae765221df94d29e9885d",
+      "id": "7c279939de15c42e651abc41949b00ee694ae0953fdeb1fed10aa662fed88237",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "a27e8feac4b03acfeff374547152cff7fc8d4f8e5feae765221df94d29e9885d",
-          "size": 37973504,
-          "asset": "mobile-canvas-v0.1.17-win-arm64.gz"
+          "sha256": "7c279939de15c42e651abc41949b00ee694ae0953fdeb1fed10aa662fed88237",
+          "size": 37993472,
+          "asset": "mobile-canvas-v0.1.17-rc.3-win-arm64.gz"
         }
       }
     },
     "win32-x64": {
       "rid": "win-x64",
       "executable": "mobile-canvas.exe",
-      "id": "3c4f6a01791c317c34915734112a246c29d5d40f5783e2122635ae5736d69dfb",
+      "id": "24986d9b0fba6be11b266e966a82c4241540c4345f97883921b2fcc208e3dccb",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "3c4f6a01791c317c34915734112a246c29d5d40f5783e2122635ae5736d69dfb",
-          "size": 37278208,
-          "asset": "mobile-canvas-v0.1.17-win-x64.gz"
+          "sha256": "24986d9b0fba6be11b266e966a82c4241540c4345f97883921b2fcc208e3dccb",
+          "size": 37298688,
+          "asset": "mobile-canvas-v0.1.17-rc.3-win-x64.gz"
         }
       }
     }
@@ -86,7 +86,7 @@
   "version": "0.1.17",
   "distribution": {
     "repository": "Redth/mobile-canvas-ghcp",
-    "tag": "v0.1.17"
+    "tag": "v0.1.17-rc.3"
   },
-  "sourceHash": "154af5992610802de57305138b3c55be6df9a5c8b967c2147335e9bb6ce88e8e"
+  "sourceHash": "f48eaccbe82f2ba1b5eef593a6a69ee402ec54a3418808a1d71c82495866862c"
 }

--- a/src/MobileCanvas.Android/AndroidSdkLocator.cs
+++ b/src/MobileCanvas.Android/AndroidSdkLocator.cs
@@ -93,17 +93,6 @@ internal sealed class AndroidSdkLocator
 		checks.Add(Tool("emulator", Emulator, "emulator not found. Install the Android Emulator package."));
 		checks.Add(Tool("avdmanager", AvdManager, "avdmanager not found. Install cmdline-tools; creating AVDs will be unavailable."));
 
-		var running = RunningDirectory;
-		checks.Add(running is not null && Directory.Exists(running)
-			? new DependencyCheck { Name = "emulator-discovery", Status = "ok", Message = "Emulator discovery directory found.", Path = running }
-			: new DependencyCheck
-			{
-				Name = "emulator-discovery",
-				Status = "warning",
-				Message = "No emulator discovery directory yet. It appears once an emulator starts.",
-				Path = running,
-			});
-
 		return [.. checks];
 
 		static DependencyCheck Tool(string name, string? path, string missingMessage) =>

--- a/src/MobileCanvas.iOS/AccessibilityParser.cs
+++ b/src/MobileCanvas.iOS/AccessibilityParser.cs
@@ -53,7 +53,7 @@ internal static partial class AccessibilityParser
 	{
 		var role = String(node, "role") ?? String(node, "type") ?? String(node, "AXRole");
 		var label = String(node, "AXLabel") ?? String(node, "label") ?? String(node, "title");
-		var value = String(node, "AXValue") ?? String(node, "value");
+		var value = ScalarString(node, "AXValue") ?? ScalarString(node, "value");
 		var identifier = String(node, "AXUniqueId") ?? String(node, "identifier") ?? String(node, "AXIdentifier");
 		var mapped = MapRole(role, String(node, "subrole"));
 
@@ -161,6 +161,19 @@ internal static partial class AccessibilityParser
 		node.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
 			? property.GetString()
 			: null;
+
+	private static string? ScalarString(JsonElement node, string name)
+	{
+		if (!node.TryGetProperty(name, out var property))
+			return null;
+
+		return property.ValueKind switch
+		{
+			JsonValueKind.String => property.GetString(),
+			JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => property.GetRawText(),
+			_ => null,
+		};
+	}
 
 	private static bool? Bool(JsonElement node, string name) =>
 		node.TryGetProperty(name, out var property) && property.ValueKind is JsonValueKind.True or JsonValueKind.False

--- a/src/MobileCanvas.iOS/IosAccessibilityFallback.cs
+++ b/src/MobileCanvas.iOS/IosAccessibilityFallback.cs
@@ -1,0 +1,39 @@
+using MobileCanvas.Core;
+
+namespace MobileCanvas.iOS;
+
+internal static class IosAccessibilityFallback
+{
+	public static async Task<T> ReadAsync<T>(
+		Func<Task<T>> readNative,
+		Func<Task<T>> readIdb)
+	{
+		try
+		{
+			return await readNative().ConfigureAwait(false);
+		}
+		catch (NativeAccessibilityException nativeException)
+		{
+			try
+			{
+				return await readIdb().ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
+			catch (Exception idbException) when (IdbCompanionManager.IsAvailabilityFailure(idbException))
+			{
+				throw BuildUnavailableException(nativeException.Message, idbException.Message);
+			}
+		}
+	}
+
+	internal static DeviceCapabilityException BuildUnavailableException(
+		string nativeFailure,
+		string idbFailure) =>
+		new(
+			"iOS accessibility hierarchy is unavailable. "
+			+ $"Bundled CoreSimulator accessibility: {nativeFailure} "
+			+ $"Optional IDB fallback: {idbFailure}");
+}

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -13,6 +13,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	private readonly IProcessRunner _processRunner;
 	private readonly CoreSimulatorHidManager _hid;
 	private readonly IdbCompanionManager _companions;
+	private readonly NativeAccessibilityReader _accessibility;
 	private readonly IosRecordingManager _recordings;
 	private readonly SimulatorDisplayProfiles _profiles;
 
@@ -37,6 +38,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		_processRunner = processRunner;
 		_hid = new CoreSimulatorHidManager();
 		_companions = new IdbCompanionManager(processRunner);
+		_accessibility = new NativeAccessibilityReader(processRunner);
 		_recordings = new IosRecordingManager(processRunner);
 		_profiles = new SimulatorDisplayProfiles(processRunner);
 	}
@@ -658,15 +660,37 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		bool includeRaw,
 		CancellationToken cancellationToken = default)
 	{
-		if (IdbCompanionLocator.Find() is null)
+		var device = await RequireBootedAsync(deviceId, cancellationToken).ConfigureAwait(false);
+		string? developerDirectory = null;
+		try
 		{
-			throw new DeviceCapabilityException(
-				"The iOS accessibility hierarchy requires the optional idb_companion. "
-				+ $"{IdbCompanionLocator.InstallationGuidance} "
-				+ "This enables ui_tree, ui_find, and ui_tap.");
+			developerDirectory = await XcodeDeveloperDirectory.ResolveSelectedAsync(
+				_processRunner,
+				cancellationToken).ConfigureAwait(false);
 		}
-		var companion = await GetCompanionAsync(deviceId, cancellationToken).ConfigureAwait(false);
-		var json = await companion.GetAccessibilityJsonAsync(cancellationToken).ConfigureAwait(false);
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception exception) when (
+			exception is ProcessExecutionException
+				or InvalidOperationException
+				or ArgumentException)
+		{
+			// The native reader reports a more specific framework/load error, and IDB remains usable.
+		}
+
+		var json = await IosAccessibilityFallback.ReadAsync(
+			() => _accessibility.ReadAsync(device.NativeId, developerDirectory, cancellationToken),
+			async () =>
+			{
+				var fallback = await GetCompanionAsync(deviceId, cancellationToken).ConfigureAwait(false);
+				var payload = await fallback.GetAccessibilityJsonAsync(cancellationToken).ConfigureAwait(false);
+				if (AccessibilityParser.Parse(payload) is null)
+					throw new InvalidDataException("idb_companion returned an invalid accessibility hierarchy.");
+				return payload;
+			}).ConfigureAwait(false);
+
 		var root = AccessibilityParser.Parse(json);
 
 		return new UiSnapshot
@@ -2483,16 +2507,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			xcodePath,
 			cancellationToken).ConfigureAwait(false);
 		var nativeHidReady = hid.Negotiable;
-		checks.Add(new DependencyCheck
-		{
-			Name = "Bundled CoreSimulator HID",
-			Status = nativeHidReady ? "ok" : companion is null ? "error" : "warning",
-			Message = nativeHidReady
-				? $"{hid.Detail} This is a static negotiability probe; a booted-device session "
-					+ "becomes authoritative when it reports ready."
-				: hid.Detail,
-			Path = NativeHelperLocator.Path,
-		});
+		checks.Add(BuildHidCheck(hid, companion));
 
 		SimulatorKitInstallation? simulatorKit = null;
 		if (xcodeReady)
@@ -2519,18 +2534,6 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			Path = simulatorKit?.FrameworkPath,
 		});
 
-		checks.Add(new DependencyCheck
-		{
-			Name = "idb_companion",
-			Status = companion is null ? "warning" : "ok",
-			Message = companion is null
-				? "Optional idb_companion is unavailable. Accessibility tree/search/tap, "
-					+ "compatibility input fallback, and the final live-video fallback are disabled."
-				: "Optional idb_companion is available for accessibility, compatibility input "
-					+ "fallback, and the final live-video fallback.",
-			Path = companion,
-		});
-
 		// Report the permission-free primary source separately from the TCC-gated fallback. Missing
 		// fallback grants only require attention when direct capture is unavailable.
 		var screencap = await ScreenCaptureHelper.GetDiagnosticsAsync(cancellationToken)
@@ -2542,7 +2545,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			Name = "Simulator framebuffer",
 			Status = framebufferReady ? "ok" : "warning",
 			Message = screencapPath is null
-				? "mobile-screencap was not found next to mobile-canvas; video falls back to idb."
+				? "mobile-screencap was not found next to mobile-canvas; bundled video sources are unavailable."
 				: framebufferReady
 					? "Direct CoreSimulator IOSurface capture is available without TCC permissions."
 					: string.IsNullOrWhiteSpace(screencap.FramebufferDetail)
@@ -2553,7 +2556,8 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		checks.Add(BuildScreencapCheck(
 			screencapPath,
 			screencap,
-			framebufferReady));
+			framebufferReady,
+			companion is not null));
 
 		return new HostDiagnostics
 		{
@@ -2563,10 +2567,28 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		};
 	}
 
+	internal static DependencyCheck BuildHidCheck(
+		CoreSimulatorHidDoctorResult hid,
+		string? companion) =>
+		new()
+		{
+			Name = "Bundled CoreSimulator HID",
+			Status = hid.Negotiable ? "ok" : companion is null ? "error" : "warning",
+			Message = hid.Negotiable
+				? $"{hid.Detail} This is a static negotiability probe; a booted-device session "
+					+ "becomes authoritative when it reports ready."
+				: companion is null
+					? $"{hid.Detail} The optional IDB input fallback is unavailable. "
+						+ IdbCompanionLocator.InstallationGuidance
+					: $"{hid.Detail} Input will use the optional IDB fallback.",
+			Path = NativeHelperLocator.Path,
+		};
+
 	internal static DependencyCheck BuildScreencapCheck(
 		string? path,
 		ScreencapDiagnostics diagnostics,
-		bool framebufferReady)
+		bool framebufferReady,
+		bool idbAvailable)
 	{
 		var screenCaptureReady = path is not null
 			&& diagnostics.ScreenRecordingGranted
@@ -2575,15 +2597,20 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		return new DependencyCheck
 		{
 			Name = "ScreenCaptureKit fallback",
-			Status = fallbackNeeded ? "warning" : "ok",
+			Status = fallbackNeeded
+				? idbAvailable ? "warning" : "error"
+				: "ok",
 			Message = path is null
-				? "The native helper is unavailable; idb is the only video fallback."
+				? idbAvailable
+					? "The native helper is unavailable; live video will use the optional IDB fallback."
+					: "The native helper and optional IDB video fallback are unavailable. "
+						+ IdbCompanionLocator.InstallationGuidance
 				: screenCaptureReady
 					? "ScreenCaptureKit and exact Accessibility geometry are available as a fallback."
 					: framebufferReady
 						? "Direct framebuffer capture is available without TCC permissions; "
 							+ "ScreenCaptureKit fallback grants are optional."
-						: BuildScreencapMessage(diagnostics, framebufferReady),
+						: BuildScreencapMessage(diagnostics, framebufferReady, idbAvailable),
 			Path = path,
 			Actions = path is not null && fallbackNeeded
 				? BuildScreencapActions(diagnostics)
@@ -2593,7 +2620,8 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 
 	private static string BuildScreencapMessage(
 		ScreencapDiagnostics diagnostics,
-		bool framebufferReady)
+		bool framebufferReady,
+		bool idbAvailable)
 	{
 		var missing = new List<string>();
 		if (!diagnostics.ScreenRecordingGranted)
@@ -2606,7 +2634,10 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		return $"Grant {permissions} in System Settings > Privacy & Security to enable "
 			+ (framebufferReady
 				? "the ScreenCaptureKit fallback; direct framebuffer capture remains available."
-				: "ScreenCaptureKit video; until then video falls back to idb.");
+				: idbAvailable
+					? "ScreenCaptureKit video; until then live video uses the optional IDB fallback."
+					: "ScreenCaptureKit video. The optional IDB fallback is also unavailable. "
+						+ IdbCompanionLocator.InstallationGuidance);
 	}
 
 	internal static DiagnosticAction[] BuildScreencapActions(ScreencapDiagnostics diagnostics)

--- a/src/MobileCanvas.iOS/NativeAccessibilityReader.cs
+++ b/src/MobileCanvas.iOS/NativeAccessibilityReader.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using MobileCanvas.Core;
+
+namespace MobileCanvas.iOS;
+
+internal sealed class NativeAccessibilityException(string message, Exception? innerException = null)
+	: IOException(message, innerException);
+
+/// <summary>Reads the iOS Simulator hierarchy through the bundled native helper.</summary>
+internal sealed class NativeAccessibilityReader(IProcessRunner processRunner)
+{
+	public Task<string> ReadAsync(
+		string udid,
+		string? developerDirectory,
+		CancellationToken cancellationToken) =>
+		ReadAsync(
+			processRunner,
+			NativeHelperLocator.Path,
+			udid,
+			developerDirectory,
+			cancellationToken);
+
+	internal static async Task<string> ReadAsync(
+		IProcessRunner processRunner,
+		string? helperPath,
+		string udid,
+		string? developerDirectory,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(helperPath))
+		{
+			throw new NativeAccessibilityException(
+				$"{NativeHelperLocator.ExecutableName} was not found next to mobile-canvas.");
+		}
+
+		var arguments = new List<string> { "accessibility", "--udid", udid };
+		if (!string.IsNullOrWhiteSpace(developerDirectory))
+		{
+			arguments.Add("--developer-dir");
+			arguments.Add(developerDirectory);
+		}
+
+		ProcessResult result;
+		try
+		{
+			result = await processRunner.RunAsync(
+				new ProcessRequest(helperPath, arguments),
+				cancellationToken).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception exception) when (
+			exception is IOException
+				or UnauthorizedAccessException
+				or InvalidOperationException)
+		{
+			throw new NativeAccessibilityException(
+				$"Could not run the bundled accessibility reader: {exception.Message}",
+				exception);
+		}
+
+		if (result.ExitCode != 0)
+		{
+			throw new NativeAccessibilityException(
+				ExtractError(result.StandardError, result.StandardOutput));
+		}
+
+		var json = result.StandardOutput.Trim();
+		if (AccessibilityParser.Parse(json) is null)
+			throw new NativeAccessibilityException("The bundled accessibility reader returned an invalid hierarchy.");
+
+		return json;
+	}
+
+	internal static string ExtractError(string standardError, string standardOutput)
+	{
+		foreach (var line in new[] { standardError, standardOutput }
+			.SelectMany(value => value.Split('\n', StringSplitOptions.RemoveEmptyEntries).Reverse()))
+		{
+			try
+			{
+				using var document = JsonDocument.Parse(line);
+				var root = document.RootElement;
+				if (root.ValueKind == JsonValueKind.Object &&
+					root.TryGetProperty("message", out var message) &&
+					message.ValueKind == JsonValueKind.String &&
+					!string.IsNullOrWhiteSpace(message.GetString()))
+				{
+					return message.GetString()!;
+				}
+			}
+			catch (JsonException)
+			{
+				// Keep looking for a structured error line before falling back to raw process output.
+			}
+		}
+
+		var detail = string.IsNullOrWhiteSpace(standardError)
+			? standardOutput.Trim()
+			: standardError.Trim();
+		return string.IsNullOrWhiteSpace(detail)
+			? "The bundled accessibility reader exited without an error message."
+			: detail;
+	}
+}

--- a/tests/MobileCanvas.Tests/AndroidDiagnosticsTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidDiagnosticsTests.cs
@@ -1,0 +1,14 @@
+using MobileCanvas.Android;
+
+namespace MobileCanvas.Tests;
+
+public sealed class AndroidDiagnosticsTests
+{
+	[Fact]
+	public void Check_DoesNotReportTransientEmulatorDiscoveryDirectory()
+	{
+		var checks = new AndroidSdkLocator().Check();
+
+		Assert.DoesNotContain(checks, check => check.Name == "emulator-discovery");
+	}
+}

--- a/tests/MobileCanvas.Tests/IosAccessibilityFallbackTests.cs
+++ b/tests/MobileCanvas.Tests/IosAccessibilityFallbackTests.cs
@@ -1,0 +1,63 @@
+using MobileCanvas.Core;
+using MobileCanvas.iOS;
+
+namespace MobileCanvas.Tests;
+
+public sealed class IosAccessibilityFallbackTests
+{
+	[Fact]
+	public async Task NativeSuccess_DoesNotStartIdb()
+	{
+		var idbCalls = 0;
+
+		var result = await IosAccessibilityFallback.ReadAsync(
+			() => Task.FromResult("native"),
+			() =>
+			{
+				idbCalls++;
+				return Task.FromResult("idb");
+			});
+
+		Assert.Equal("native", result);
+		Assert.Equal(0, idbCalls);
+	}
+
+	[Fact]
+	public async Task NativeFailure_UsesIdb()
+	{
+		var result = await IosAccessibilityFallback.ReadAsync(
+			() => Task.FromException<string>(new NativeAccessibilityException("native unavailable")),
+			() => Task.FromResult("idb"));
+
+		Assert.Equal("idb", result);
+	}
+
+	[Fact]
+	public async Task BothUnavailable_ReportBothReasons()
+	{
+		var exception = await Assert.ThrowsAsync<DeviceCapabilityException>(
+			() => IosAccessibilityFallback.ReadAsync(
+				() => Task.FromException<string>(new NativeAccessibilityException("native reason")),
+				() => Task.FromException<string>(new FileNotFoundException("idb reason"))));
+
+		Assert.Contains("native reason", exception.Message);
+		Assert.Contains("idb reason", exception.Message);
+	}
+
+	[Fact]
+	public async Task Cancellation_DoesNotInvokeIdb()
+	{
+		var idbCalls = 0;
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			() => IosAccessibilityFallback.ReadAsync(
+				() => Task.FromCanceled<string>(new CancellationToken(canceled: true)),
+				() =>
+				{
+					idbCalls++;
+					return Task.FromResult("idb");
+				}));
+
+		Assert.Equal(0, idbCalls);
+	}
+}

--- a/tests/MobileCanvas.Tests/NativeAccessibilityReaderTests.cs
+++ b/tests/MobileCanvas.Tests/NativeAccessibilityReaderTests.cs
@@ -1,0 +1,98 @@
+using MobileCanvas.Core;
+using MobileCanvas.iOS;
+
+namespace MobileCanvas.Tests;
+
+public sealed class NativeAccessibilityReaderTests
+{
+	private const string Hierarchy = """
+		{
+		  "role": "AXApplication",
+		  "frame": { "x": 0, "y": 0, "width": 390, "height": 844 },
+		  "children": [
+		    {
+		      "role": "AXButton",
+		      "AXLabel": "Continue",
+		      "frame": { "x": 20, "y": 700, "width": 350, "height": 44 },
+		      "children": []
+		    }
+		  ]
+		}
+		""";
+
+	[Fact]
+	public async Task ReadAsync_TargetsUdidAndDeveloperDirectory()
+	{
+		var runner = new RecordingProcessRunner(new ProcessResult(0, Hierarchy, ""));
+
+		var json = await NativeAccessibilityReader.ReadAsync(
+			runner,
+			"/tmp/mobile-screencap",
+			"SIM-UDID",
+			"/Applications/Xcode.app/Contents/Developer",
+			CancellationToken.None);
+
+		Assert.Equal(Hierarchy.Trim(), json);
+		var request = Assert.Single(runner.Requests);
+		Assert.Equal("/tmp/mobile-screencap", request.FileName);
+		Assert.Equal(
+			[
+				"accessibility",
+				"--udid",
+				"SIM-UDID",
+				"--developer-dir",
+				"/Applications/Xcode.app/Contents/Developer",
+			],
+			request.Arguments);
+	}
+
+	[Fact]
+	public async Task ReadAsync_RejectsInvalidHierarchy()
+	{
+		var runner = new RecordingProcessRunner(new ProcessResult(0, "not-json", ""));
+
+		var exception = await Assert.ThrowsAsync<NativeAccessibilityException>(
+			() => NativeAccessibilityReader.ReadAsync(
+				runner,
+				"/tmp/mobile-screencap",
+				"SIM-UDID",
+				null,
+				CancellationToken.None));
+
+		Assert.Contains("invalid hierarchy", exception.Message);
+	}
+
+	[Fact]
+	public async Task ReadAsync_UsesStructuredHelperError()
+	{
+		var runner = new RecordingProcessRunner(new ProcessResult(
+			1,
+			"""
+			{"type":"unavailable","code":"timeout","message":"accessibility translation timed out"}
+			""",
+			""));
+
+		var exception = await Assert.ThrowsAsync<NativeAccessibilityException>(
+			() => NativeAccessibilityReader.ReadAsync(
+				runner,
+				"/tmp/mobile-screencap",
+				"SIM-UDID",
+				null,
+				CancellationToken.None));
+
+		Assert.Equal("accessibility translation timed out", exception.Message);
+	}
+
+	private sealed class RecordingProcessRunner(ProcessResult result) : IProcessRunner
+	{
+		public List<ProcessRequest> Requests { get; } = [];
+
+		public Task<ProcessResult> RunAsync(
+			ProcessRequest request,
+			CancellationToken cancellationToken = default)
+		{
+			Requests.Add(request);
+			return Task.FromResult(result);
+		}
+	}
+}

--- a/tests/MobileCanvas.Tests/NativeCaptureTests.cs
+++ b/tests/MobileCanvas.Tests/NativeCaptureTests.cs
@@ -114,6 +114,29 @@ public class NativeCaptureTests
 	}
 
 	[Fact]
+	public void HidCheck_MentionsIdbOnlyWhenNativeInputNeedsIt()
+	{
+		var healthy = IosSimulatorBackend.BuildHidCheck(
+			new CoreSimulatorHidDoctorResult
+			{
+				Negotiable = true,
+				Detail = "DTUHID is available.",
+			},
+			companion: null);
+		var unavailable = IosSimulatorBackend.BuildHidCheck(
+			new CoreSimulatorHidDoctorResult
+			{
+				Negotiable = false,
+				Detail = "DTUHID is unavailable.",
+			},
+			companion: null);
+
+		Assert.DoesNotContain("IDB", healthy.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Equal("error", unavailable.Status);
+		Assert.Contains("IDB input fallback is unavailable", unavailable.Message);
+	}
+
+	[Fact]
 	public void ScreencapCheck_DoesNotPromptForOptionalFallbackPermissions()
 	{
 		var check = IosSimulatorBackend.BuildScreencapCheck(
@@ -123,7 +146,8 @@ public class NativeCaptureTests
 				ScreenRecordingGranted = false,
 				AccessibilityGranted = false,
 			},
-			framebufferReady: true);
+			framebufferReady: true,
+			idbAvailable: false);
 
 		Assert.Equal("ok", check.Status);
 		Assert.Contains("fallback grants are optional", check.Message);
@@ -140,7 +164,8 @@ public class NativeCaptureTests
 				ScreenRecordingGranted = false,
 				AccessibilityGranted = false,
 			},
-			framebufferReady: false);
+			framebufferReady: false,
+			idbAvailable: true);
 
 		Assert.Equal("warning", check.Status);
 		Assert.StartsWith("Grant Screen Recording and Accessibility", check.Message);
@@ -148,6 +173,25 @@ public class NativeCaptureTests
 			check.Actions,
 			action => Assert.Equal(SystemSettingsTargets.ScreenRecording, action.Target),
 			action => Assert.Equal(SystemSettingsTargets.Accessibility, action.Target));
+	}
+
+	[Fact]
+	public void ScreencapCheck_ReportsIdbOnlyWhenNativeVideoNeedsIt()
+	{
+		var healthy = IosSimulatorBackend.BuildScreencapCheck(
+			"/tmp/mobile-screencap",
+			new ScreencapDiagnostics(),
+			framebufferReady: true,
+			idbAvailable: false);
+		var unavailable = IosSimulatorBackend.BuildScreencapCheck(
+			"/tmp/mobile-screencap",
+			new ScreencapDiagnostics(),
+			framebufferReady: false,
+			idbAvailable: false);
+
+		Assert.DoesNotContain("IDB", healthy.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Equal("error", unavailable.Status);
+		Assert.Contains("IDB fallback is also unavailable", unavailable.Message);
 	}
 
 	[Fact]

--- a/tests/MobileCanvas.Tests/UiTreeTests.cs
+++ b/tests/MobileCanvas.Tests/UiTreeTests.cs
@@ -99,6 +99,23 @@ public sealed class UiTreeTests
 		Assert.Null(root!.Label);
 	}
 
+	[Theory]
+	[InlineData("0.75", "0.75")]
+	[InlineData("true", "true")]
+	public void ParseIos_PreservesScalarControlValues(string jsonValue, string expected)
+	{
+		var root = AccessibilityParser.Parse(
+			$$"""
+			{
+			  "role": "AXSlider",
+			  "AXValue": {{jsonValue}},
+			  "children": []
+			}
+			""");
+
+		Assert.Equal(expected, root!.Value);
+	}
+
 	[Fact]
 	public void ParseAndroid_ConvertsPixelBoundsToPoints()
 	{

--- a/tests/web/idb-guidance.test.mjs
+++ b/tests/web/idb-guidance.test.mjs
@@ -36,6 +36,38 @@ test("missing IDB diagnostics use the same actionable guidance", () => {
   assert.equal(popover[0].message, expected);
 });
 
+test("optional missing IDB diagnostics stay out of the device dropdown", () => {
+  const { popover } = organizeDiagnostics([
+    {
+      checks: [
+        {
+          name: "idb_companion",
+          status: "warning",
+          message: "Optional idb_companion is unavailable. Compatibility fallbacks are disabled.",
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(popover, []);
+});
+
+test("transient Android emulator discovery state stays out of the device dropdown", () => {
+  const { popover } = organizeDiagnostics([
+    {
+      checks: [
+        {
+          name: "emulator-discovery",
+          status: "warning",
+          message: "No emulator discovery directory yet. It appears once an emulator starts.",
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(popover, []);
+});
+
 test("unrelated runtime failures pass through unchanged", () => {
   const message = "idb_companion exited with code 1";
   assert.equal(formatUserFacingMessage(message), message);

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -67,11 +67,12 @@ Mobile Canvas or .NET tool to install.
 |---|---|
 | iOS | macOS and a full Xcode installation with Simulator runtimes |
 | Android | Android SDK tools and `adb` on `PATH` |
-| Optional iOS accessibility/fallbacks | [`idb`](https://fbidb.io) (provides `idb_companion`) |
+| Optional iOS fallbacks | [`idb`](https://fbidb.io) (provides `idb_companion`) |
 
-The bundled helper provides iOS touch, keyboard, buttons, rotation, and direct
-video capture. Install Meta's `idb` package only for accessibility hierarchy,
-compatibility input fallback, or the final live-video fallback:
+The bundled helper provides iOS touch, keyboard, buttons, rotation,
+accessibility hierarchy, and direct video capture. Meta's `idb` package is only
+a compatibility input fallback and the final live-video fallback; Mobile Canvas
+does not report it missing unless a native path actually needs it:
 
 ```bash
 brew tap facebook/fb

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -95,6 +95,7 @@ export function organizeDiagnostics(diagnostics) {
   const failures = (diagnostics ?? [])
     .flatMap((entry) => entry?.checks ?? [])
     .filter((check) => check?.status !== "ok")
+    .filter(isActionableDiagnostic)
     .map((check) => ({
       ...check,
       message: formatUserFacingMessage(check.message),
@@ -116,6 +117,19 @@ export function organizeDiagnostics(diagnostics) {
   }
 
   return { notices, popover };
+}
+
+function isActionableDiagnostic(check) {
+  const name = String(check?.name ?? "").toLowerCase();
+  const status = String(check?.status ?? "").toLowerCase();
+  const message = String(check?.message ?? "").toLowerCase();
+
+  if (name === "emulator-discovery" && status === "warning") return false;
+  return !(
+    name === "idb_companion"
+    && status === "warning"
+    && message.startsWith("optional idb_companion is unavailable")
+  );
 }
 
 export function shouldDrainIdleDecoder(source) {


### PR DESCRIPTION
Missing `idb_companion` currently produces a prominent device-dropdown warning even when native input and video are healthy, while iOS hierarchy operations genuinely depend on IDB. This change makes the bundled helper provide the hierarchy directly and limits fallback guidance to cases where it is actionable.

## What changed

- Added a bounded, runtime-loaded CoreSimulator accessibility reader to `mobile-screencap`.
- Routed iOS UI tree reads through the native reader first, with installed IDB retained as a silent compatibility fallback.
- Kept search and element tap on the existing shared `UiTree` and native HID paths.
- Removed the transient Android emulator discovery directory from dependency warnings.
- Suppressed optional missing-IDB notices unless a native input, hierarchy, or video path actually needs the fallback.
- Updated shared GitHub App/VS Code documentation, tests, and MIT attribution.

## Implementation notes

The hierarchy reader uses private CoreSimulator accessibility translation APIs, consistent with the existing framebuffer and HID integrations. Framework and selector availability are checked at runtime, request waits and traversal size are bounded, and failures fall back to IDB without changing the normal native path.

## Validation

- Native helper tests pass for arm64 and x86_64.
- 353 managed tests pass.
- VS Code build and 79 shared/extension unit tests pass.
- Live hierarchy dump, search, and element tap were exercised against booted iOS 26 and iOS 27 simulators.