### PR TITLE
Harden virtual device creation

### DIFF
--- a/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
+++ b/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
@@ -30,7 +30,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		"https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/android-setup.md";
 	private static readonly string[] RequiredSdkChecks = ["android-sdk", "adb", "emulator"];
 
-	private readonly AndroidSdkLocator _locator = new();
+	private readonly AndroidSdkLocator _locator;
 	private readonly EmulatorConnectionPool _connections = new();
 	private readonly EmulatorDiscovery _discovery;
 	private readonly IProcessRunner _processRunner;
@@ -62,9 +62,18 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	private readonly Dictionary<string, DisplayGeometry> _geometryCache = new(StringComparer.OrdinalIgnoreCase);
 
 	public AndroidEmulatorBackend(IProcessRunner processRunner, ILogger<AndroidEmulatorBackend> logger)
+		: this(processRunner, logger, new AndroidSdkLocator())
+	{
+	}
+
+	internal AndroidEmulatorBackend(
+		IProcessRunner processRunner,
+		ILogger<AndroidEmulatorBackend> logger,
+		AndroidSdkLocator locator)
 	{
 		_processRunner = processRunner;
 		_logger = logger;
+		_locator = locator;
 		_discovery = new EmulatorDiscovery(_locator, processRunner);
 		_recordings = new AndroidRecordingManager(this, logger);
 	}
@@ -111,7 +120,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		return new DeviceCatalog
 		{
 			Devices = devices,
-			Runtimes = BuildRuntimes(devices),
+			Runtimes = BuildRuntimes(devices, _locator.GetInstalledSystemImages()),
 			DeviceTypes = avdManager.DeviceTypes,
 			Diagnostics = [diagnostics],
 		};
@@ -238,7 +247,9 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 			State = state,
 			IsAvailable = true,
 			IsVirtual = true,
-			RuntimeId = config.GetValueOrDefault("image.sysdir.1"),
+			RuntimeId = config.GetValueOrDefault("image.sysdir.1") is { Length: > 0 } systemImage
+				? ToSystemImagePackage(systemImage)
+				: null,
 			RuntimeName = DescribeRuntime(config),
 			OsVersion = DescribeApiLevel(config),
 			DeviceTypeId = config.GetValueOrDefault("hw.device.name"),
@@ -280,26 +291,54 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		};
 	}
 
-	private static DeviceRuntime[] BuildRuntimes(DeviceTarget[] devices)
+	internal static DeviceRuntime[] BuildRuntimes(
+		DeviceTarget[] devices,
+		IReadOnlyList<AndroidSystemImage> installedSystemImages)
 	{
-		// sdkmanager is slow and network-aware, so runtimes are derived from what the configured AVDs
-		// actually reference. That is also the only set a user can create against offline.
-		return [.. devices
-			.Where(d => !string.IsNullOrEmpty(d.RuntimeId))
-			.GroupBy(d => d.RuntimeId!, StringComparer.OrdinalIgnoreCase)
-			.Select(g => new DeviceRuntime
+		var installed = installedSystemImages.Select(image => new RuntimeCandidate(
+			image.PackageId,
+			$"API {image.Version} ({PrettifyAvdName(image.Tag)}, {image.Architecture})",
+			image.Version,
+			image.Architecture,
+			IsInstalled: true));
+		var configured = devices
+			.Where(device => !string.IsNullOrWhiteSpace(device.RuntimeId))
+			.Select(device => new RuntimeCandidate(
+				ToSystemImagePackage(device.RuntimeId!),
+				device.RuntimeName ?? device.RuntimeId!,
+				device.OsVersion ?? "",
+				device.Architecture,
+				IsInstalled: false));
+
+		return [.. installed
+			.Concat(configured)
+			.GroupBy(runtime => runtime.Id, StringComparer.OrdinalIgnoreCase)
+			.Select(group =>
 			{
-				Id = ToSystemImagePackage(g.Key),
-				Name = g.First().RuntimeName ?? g.Key,
-				Version = g.First().OsVersion ?? "",
-				Platform = DevicePlatforms.Android,
-				IsAvailable = true,
-				SupportedArchitectures = [.. g.Select(d => d.Architecture)
-					.Where(a => !string.IsNullOrEmpty(a))
-					.Distinct(StringComparer.OrdinalIgnoreCase)!],
+				var preferred = group.OrderByDescending(runtime => runtime.IsInstalled).First();
+				return new DeviceRuntime
+				{
+					Id = group.Key,
+					Name = preferred.Name,
+					Version = preferred.Version,
+					Platform = DevicePlatforms.Android,
+					IsAvailable = group.Any(runtime => runtime.IsInstalled),
+					SupportedArchitectures = [.. group
+						.Select(runtime => runtime.Architecture)
+						.Where(static architecture => !string.IsNullOrWhiteSpace(architecture))
+						.Select(static architecture => architecture!)
+						.Distinct(StringComparer.OrdinalIgnoreCase)],
+				};
 			})
 			.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)];
 	}
+
+	private sealed record RuntimeCandidate(
+		string Id,
+		string Name,
+		string Version,
+		string? Architecture,
+		bool IsInstalled);
 
 	private async Task<AvdManagerProbe> GetAvdManagerProbeAsync(
 		bool force,
@@ -414,32 +453,70 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		if (string.IsNullOrWhiteSpace(request.RuntimeId))
 			throw new ArgumentException("A system image (runtimeId) is required to create an AVD.", nameof(request));
 
+		var requestedRuntimeId = ToSystemImagePackage(request.RuntimeId);
+		var runtime = _locator.GetInstalledSystemImages().FirstOrDefault(image =>
+			image.PackageId.Equals(requestedRuntimeId, StringComparison.OrdinalIgnoreCase));
+		if (runtime is null)
+		{
+			throw new ArgumentException(
+				$"System image '{request.RuntimeId}' is not installed.",
+				nameof(request));
+		}
+
 		var name = SanitizeAvdName(request.Name);
 		var avdManager = await RequireAvdManagerAsync(cancellationToken).ConfigureAwait(false);
-		var arguments = new List<string>
-		{
-			"create", "avd", "--name", name, "--package", request.RuntimeId, "--force",
-		};
-
-		if (!string.IsNullOrWhiteSpace(request.DeviceTypeId))
-		{
-			arguments.Add("--device");
-			arguments.Add(request.DeviceTypeId);
-		}
+		var arguments = BuildCreateArguments(name, runtime.PackageId, request.DeviceTypeId);
 
 		// avdmanager prompts on stdin for a custom hardware profile; "no" accepts the image default.
 		var result = await _processRunner
 			.RunAsync(
-				_locator.CreateAvdManagerRequest([.. arguments], standardInput: "no\n"),
+				_locator.CreateAvdManagerRequest(arguments, standardInput: "no\n"),
 				cancellationToken)
 			.ConfigureAwait(false);
 
 		if (result.ExitCode != 0)
 			throw new ProcessExecutionException(avdManager, arguments, result);
 
-		return await GetDeviceAsync(
-			DeviceIdentity.Create(Platform, ProviderId, name),
+		var deviceId = DeviceIdentity.Create(Platform, ProviderId, name);
+		return await CreationRollback.ResolveAsync(
+			resolve: token => GetDeviceAsync(deviceId, token),
+			rollback: token => DeleteCreatedAvdAsync(avdManager, name, token),
+			resourceDescription: $"Android AVD '{name}'",
 			cancellationToken).ConfigureAwait(false);
+	}
+
+	internal static string[] BuildCreateArguments(
+		string name,
+		string runtimeId,
+		string? deviceTypeId)
+	{
+		var arguments = new List<string>
+		{
+			"create", "avd", "--name", name, "--package", runtimeId,
+		};
+
+		if (!string.IsNullOrWhiteSpace(deviceTypeId))
+		{
+			arguments.Add("--device");
+			arguments.Add(deviceTypeId);
+		}
+
+		return [.. arguments];
+	}
+
+	private async Task DeleteCreatedAvdAsync(
+		string avdManager,
+		string name,
+		CancellationToken cancellationToken)
+	{
+		var arguments = new[] { "delete", "avd", "--name", name };
+		var result = await _processRunner
+			.RunAsync(_locator.CreateAvdManagerRequest(arguments), cancellationToken)
+			.ConfigureAwait(false);
+		if (result.ExitCode != 0)
+			throw new ProcessExecutionException(avdManager, arguments, result);
+
+		InvalidateCache(name);
 	}
 
 	public async Task<DeviceTarget> BootAsync(string deviceId, CancellationToken cancellationToken = default)
@@ -3789,9 +3866,11 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	/// <c>avdmanager --package</c> expects, so a listed runtime can be passed straight back to create.
 	/// </summary>
 	internal static string ToSystemImagePackage(string sysdir) =>
-		string.Join(';', sysdir.Trim('/', '\\').Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries));
+		string.Join(
+			';',
+			sysdir.Trim().Trim('/', '\\').Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries));
 
-	private static string SanitizeAvdName(string name)
+	internal static string SanitizeAvdName(string name)
 	{
 		// avdmanager rejects spaces and most punctuation in AVD names.
 		var cleaned = AvdNamePattern().Replace(name, "_").Trim('_');

--- a/src/MobileCanvas.Android/AndroidSdkLocator.cs
+++ b/src/MobileCanvas.Android/AndroidSdkLocator.cs
@@ -79,6 +79,12 @@ internal sealed class AndroidSdkLocator
 				var tag = Path.GetFileName(tagDirectory);
 				foreach (var architectureDirectory in EnumerateDirectories(tagDirectory))
 				{
+					if (!File.Exists(Path.Combine(architectureDirectory, "package.xml"))
+						&& !File.Exists(Path.Combine(architectureDirectory, "source.properties")))
+					{
+						continue;
+					}
+
 					var architecture = Path.GetFileName(architectureDirectory);
 					results.Add(new AndroidSystemImage(
 						$"system-images;{platform};{tag};{architecture}",

--- a/src/MobileCanvas.Android/AndroidSdkLocator.cs
+++ b/src/MobileCanvas.Android/AndroidSdkLocator.cs
@@ -11,7 +11,20 @@ namespace MobileCanvas.Android;
 /// </summary>
 internal sealed class AndroidSdkLocator
 {
-	private readonly Lazy<string?> _sdkRoot = new(FindSdkRoot);
+	private readonly Lazy<string?> _sdkRoot;
+
+	internal AndroidSdkLocator() : this(FindSdkRoot)
+	{
+	}
+
+	internal AndroidSdkLocator(string? sdkRoot) : this(() => sdkRoot)
+	{
+	}
+
+	private AndroidSdkLocator(Func<string?> findSdkRoot)
+	{
+		_sdkRoot = new Lazy<string?>(findSdkRoot);
+	}
 
 	public string? SdkRoot => _sdkRoot.Value;
 
@@ -43,6 +56,44 @@ internal sealed class AndroidSdkLocator
 
 			return candidates.FirstOrDefault(File.Exists);
 		}
+	}
+
+	public IReadOnlyList<AndroidSystemImage> GetInstalledSystemImages() =>
+		SdkRoot is { } root ? FindInstalledSystemImages(root) : [];
+
+	internal static IReadOnlyList<AndroidSystemImage> FindInstalledSystemImages(string sdkRoot)
+	{
+		var systemImages = Path.Combine(sdkRoot, "system-images");
+		if (!Directory.Exists(systemImages))
+			return [];
+
+		var results = new List<AndroidSystemImage>();
+		foreach (var platformDirectory in EnumerateDirectories(systemImages))
+		{
+			var platform = Path.GetFileName(platformDirectory);
+			if (!platform.StartsWith("android-", StringComparison.OrdinalIgnoreCase))
+				continue;
+
+			foreach (var tagDirectory in EnumerateDirectories(platformDirectory))
+			{
+				var tag = Path.GetFileName(tagDirectory);
+				foreach (var architectureDirectory in EnumerateDirectories(tagDirectory))
+				{
+					var architecture = Path.GetFileName(architectureDirectory);
+					results.Add(new AndroidSystemImage(
+						$"system-images;{platform};{tag};{architecture}",
+						platform["android-".Length..],
+						tag,
+						architecture));
+				}
+			}
+		}
+
+		return results
+			.OrderByDescending(image => ParseVersion(image.Version))
+			.ThenBy(image => image.Tag, StringComparer.OrdinalIgnoreCase)
+			.ThenBy(image => image.Architecture, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
 	}
 
 	/// <summary>
@@ -204,7 +255,32 @@ internal sealed class AndroidSdkLocator
 
 		return defaults.FirstOrDefault(Directory.Exists);
 	}
+
+	private static Version ParseVersion(string value) =>
+		Version.TryParse(value, out var parsed) ? parsed : new Version();
+
+	private static IEnumerable<string> EnumerateDirectories(string path)
+	{
+		try
+		{
+			return Directory.EnumerateDirectories(path).ToArray();
+		}
+		catch (IOException)
+		{
+			return [];
+		}
+		catch (UnauthorizedAccessException)
+		{
+			return [];
+		}
+	}
 }
+
+internal sealed record AndroidSystemImage(
+	string PackageId,
+	string Version,
+	string Tag,
+	string Architecture);
 
 /// <summary>
 /// Enumerates configured AVDs and running emulator instances, and joins them to adb serials.

--- a/src/MobileCanvas.Core/CreationRollback.cs
+++ b/src/MobileCanvas.Core/CreationRollback.cs
@@ -1,0 +1,39 @@
+namespace MobileCanvas.Core;
+
+public static class CreationRollback
+{
+	private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(30);
+
+	public static async Task<T> ResolveAsync<T>(
+		Func<CancellationToken, Task<T>> resolve,
+		Func<CancellationToken, Task> rollback,
+		string resourceDescription,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(resolve);
+		ArgumentNullException.ThrowIfNull(rollback);
+		ArgumentException.ThrowIfNullOrWhiteSpace(resourceDescription);
+
+		try
+		{
+			return await resolve(cancellationToken).ConfigureAwait(false);
+		}
+		catch (Exception resolutionException)
+		{
+			using var cleanupSource = new CancellationTokenSource(CleanupTimeout);
+			try
+			{
+				await rollback(cleanupSource.Token).ConfigureAwait(false);
+			}
+			catch (Exception rollbackException)
+			{
+				throw new AggregateException(
+					$"{resourceDescription} was created but could not be resolved, and rollback also failed.",
+					resolutionException,
+					rollbackException);
+			}
+
+			throw;
+		}
+	}
+}

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -169,9 +169,19 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		var result = await RunAsync(arguments, cancellationToken).ConfigureAwait(false);
 		EnsureSuccess("xcrun", ["simctl", .. arguments], result);
 		var udid = result.StandardOutput.Trim();
-		return await GetDeviceAsync(
-			DeviceIdentity.Create(DevicePlatforms.Ios, "core-simulator", udid),
+		var deviceId = DeviceIdentity.Create(DevicePlatforms.Ios, "core-simulator", udid);
+		return await CreationRollback.ResolveAsync(
+			resolve: token => GetDeviceAsync(deviceId, token),
+			rollback: token => DeleteCreatedSimulatorAsync(udid, token),
+			resourceDescription: $"iOS simulator '{udid}'",
 			cancellationToken).ConfigureAwait(false);
+	}
+
+	private async Task DeleteCreatedSimulatorAsync(string udid, CancellationToken cancellationToken)
+	{
+		var arguments = new[] { "delete", udid };
+		var result = await RunAsync(arguments, cancellationToken).ConfigureAwait(false);
+		EnsureSuccess("xcrun", ["simctl", .. arguments], result);
 	}
 
 	public async Task<DeviceTarget> BootAsync(string deviceId, CancellationToken cancellationToken = default)

--- a/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
@@ -214,6 +214,8 @@ public sealed class AndroidEmulatorBackendTests
 			"arm64-v8a");
 		Directory.CreateDirectory(olderImage);
 		Directory.CreateDirectory(newerImage);
+		File.WriteAllText(Path.Combine(olderImage, "source.properties"), "Pkg.Revision=1\n");
+		File.WriteAllText(Path.Combine(newerImage, "package.xml"), "<repository />\n");
 
 		try
 		{
@@ -232,6 +234,28 @@ public sealed class AndroidEmulatorBackendTests
 					Assert.Equal("google_apis", runtime.Tag);
 					Assert.Equal("arm64-v8a", runtime.Architecture);
 				});
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[Fact]
+	public void InstalledSystemImages_IgnoreInterruptedDirectoriesWithoutPackageMetadata()
+	{
+		var root = Directory.CreateTempSubdirectory("mobile-canvas-sdk-").FullName;
+		var partialImage = Path.Combine(
+			root,
+			"system-images",
+			"android-35",
+			"google_apis",
+			"arm64-v8a");
+		Directory.CreateDirectory(partialImage);
+
+		try
+		{
+			Assert.Empty(AndroidSdkLocator.FindInstalledSystemImages(root));
 		}
 		finally
 		{
@@ -439,12 +463,14 @@ public sealed class AndroidEmulatorBackendTests
 			CreateTool("platform-tools", Executable("adb"));
 			CreateTool("emulator", Executable("emulator"));
 			AvdManager = CreateTool("cmdline-tools", "latest", "bin", Script("avdmanager"));
-			Directory.CreateDirectory(Path.Combine(
+			var systemImage = Path.Combine(
 				Root,
 				"system-images",
 				"android-35",
 				"google_apis",
-				"arm64-v8a"));
+				"arm64-v8a");
+			Directory.CreateDirectory(systemImage);
+			File.WriteAllText(Path.Combine(systemImage, "source.properties"), "Pkg.Revision=1\n");
 		}
 
 		public string Root { get; }

--- a/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
@@ -1,6 +1,7 @@
 using MobileCanvas.Android;
 using MobileCanvas.Contracts;
 using MobileCanvas.Core;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MobileCanvas.Tests;
 
@@ -147,4 +148,321 @@ public sealed class AndroidEmulatorBackendTests
 
 	private static DependencyCheck Check(string name, string status) =>
 		new() { Name = name, Status = status };
+
+	[Theory]
+	[InlineData("Pixel 8 Pro", "Pixel_8_Pro")]
+	[InlineData("foo/bar", "foo_bar")]
+	[InlineData("///", "mobile_canvas_avd")]
+	public void SanitizeAvdName_ProducesSafeStableNames(string name, string expected)
+	{
+		Assert.Equal(expected, AndroidEmulatorBackend.SanitizeAvdName(name));
+	}
+
+	[Fact]
+	public void CreateArguments_UseTheCanonicalPackageWithoutForce()
+	{
+		var arguments = AndroidEmulatorBackend.BuildCreateArguments(
+			"foo_bar",
+			"system-images;android-35;google_apis;arm64-v8a",
+			"pixel_8");
+
+		Assert.Equal(
+			new[]
+			{
+				"create",
+				"avd",
+				"--name",
+				"foo_bar",
+				"--package",
+				"system-images;android-35;google_apis;arm64-v8a",
+				"--device",
+				"pixel_8",
+			},
+			arguments);
+	}
+
+	[Theory]
+	[InlineData(
+		"system-images/android-35/google_apis/arm64-v8a/",
+		"system-images;android-35;google_apis;arm64-v8a")]
+	[InlineData(
+		@"system-images\android-35\google_apis\arm64-v8a\",
+		"system-images;android-35;google_apis;arm64-v8a")]
+	[InlineData(
+		" system-images;android-35;google_apis;arm64-v8a ",
+		"system-images;android-35;google_apis;arm64-v8a")]
+	public void RuntimeIdNormalization_UsesTheAvdManagerPackageId(string runtimeId, string expected)
+	{
+		Assert.Equal(expected, AndroidEmulatorBackend.ToSystemImagePackage(runtimeId));
+	}
+
+	[Fact]
+	public void InstalledSystemImages_AreCreatableWithoutAnExistingAvd()
+	{
+		var root = Directory.CreateTempSubdirectory("mobile-canvas-sdk-").FullName;
+		var olderImage = Path.Combine(
+			root,
+			"system-images",
+			"android-35",
+			"google_apis",
+			"arm64-v8a");
+		var newerImage = Path.Combine(
+			root,
+			"system-images",
+			"android-36.1",
+			"google_apis",
+			"arm64-v8a");
+		Directory.CreateDirectory(olderImage);
+		Directory.CreateDirectory(newerImage);
+
+		try
+		{
+			var installed = AndroidSdkLocator.FindInstalledSystemImages(root);
+			Assert.Collection(
+				installed,
+				runtime =>
+				{
+					Assert.Equal("system-images;android-36.1;google_apis;arm64-v8a", runtime.PackageId);
+					Assert.Equal("36.1", runtime.Version);
+				},
+				runtime =>
+				{
+					Assert.Equal("system-images;android-35;google_apis;arm64-v8a", runtime.PackageId);
+					Assert.Equal("35", runtime.Version);
+					Assert.Equal("google_apis", runtime.Tag);
+					Assert.Equal("arm64-v8a", runtime.Architecture);
+				});
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[Fact]
+	public void RuntimeCatalog_MapsInstalledImagesToCanonicalPackageIds()
+	{
+		var runtimes = AndroidEmulatorBackend.BuildRuntimes(
+			[
+				new DeviceTarget
+				{
+					RuntimeId = @"system-images\android-35\google_apis\arm64-v8a",
+					RuntimeName = "API 35 (Google APIs)",
+					OsVersion = "35",
+					Architecture = "arm64-v8a",
+				},
+			],
+			[
+				new AndroidSystemImage(
+					"system-images;android-35;google_apis;arm64-v8a",
+					"35",
+					"google_apis",
+					"arm64-v8a"),
+			]);
+
+		var runtime = Assert.Single(runtimes);
+		Assert.Equal("system-images;android-35;google_apis;arm64-v8a", runtime.Id);
+		Assert.Equal("35", runtime.Version);
+		Assert.Equal(["arm64-v8a"], runtime.SupportedArchitectures);
+		Assert.True(runtime.IsAvailable);
+	}
+
+	[Fact]
+	public void RuntimeCatalog_MarksConfiguredButUninstalledImagesUnavailable()
+	{
+		var runtimes = AndroidEmulatorBackend.BuildRuntimes(
+			[
+				new DeviceTarget
+				{
+					RuntimeId = "system-images/android-34/google_apis/x86_64/",
+					RuntimeName = "API 34 (Google APIs)",
+					OsVersion = "34",
+					Architecture = "x86_64",
+				},
+			],
+			[]);
+
+		var runtime = Assert.Single(runtimes);
+		Assert.Equal("system-images;android-34;google_apis;x86_64", runtime.Id);
+		Assert.False(runtime.IsAvailable);
+	}
+
+	[Fact]
+	public async Task CreateAsync_RejectsAnUninstalledRuntimeBeforeLaunchingAvdManager()
+	{
+		using var sdk = new AndroidSdkFixture();
+		var runner = new RecordingProcessRunner((request, _) =>
+			throw new InvalidOperationException($"Unexpected process request: {request.FileName}"));
+		await using var backend = new AndroidEmulatorBackend(
+			runner,
+			NullLogger<AndroidEmulatorBackend>.Instance,
+			new AndroidSdkLocator(sdk.Root));
+
+		var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+			backend.CreateAsync(new CreateDeviceRequest
+			{
+				Name = "missing runtime",
+				RuntimeId = "system-images;android-34;google_apis;arm64-v8a",
+				DeviceTypeId = "pixel_8",
+			}));
+
+		Assert.Contains("is not installed", exception.Message, StringComparison.Ordinal);
+		Assert.Empty(runner.Calls);
+	}
+
+	[Fact]
+	public async Task CreateAsync_MapsAnExistingAvdCollisionWithoutDeletingIt()
+	{
+		using var sdk = new AndroidSdkFixture();
+		var runner = new RecordingProcessRunner((request, _) =>
+		{
+			var arguments = GetAvdManagerArguments(request);
+			if (arguments.SequenceEqual(["list", "device", "-c"]))
+				return new ProcessResult(0, "pixel_8\n", "");
+
+			Assert.Equal("create", arguments[0]);
+			return new ProcessResult(1, "", "Android Virtual Device 'existing_device' already exists.");
+		});
+		await using var backend = new AndroidEmulatorBackend(
+			runner,
+			NullLogger<AndroidEmulatorBackend>.Instance,
+			new AndroidSdkLocator(sdk.Root));
+
+		var exception = await Assert.ThrowsAsync<ProcessExecutionException>(() =>
+			backend.CreateAsync(new CreateDeviceRequest
+			{
+				Name = "existing/device",
+				RuntimeId = "system-images/android-35/google_apis/arm64-v8a/",
+				DeviceTypeId = "pixel_8",
+			}));
+
+		Assert.Contains("already exists", exception.Message, StringComparison.Ordinal);
+		var call = Assert.Single(
+			runner.Calls,
+			call => GetAvdManagerArguments(call.Request).FirstOrDefault() == "create");
+		Assert.Equal(
+			new[]
+			{
+				"create",
+				"avd",
+				"--name",
+				"existing_device",
+				"--package",
+				sdk.RuntimeId,
+				"--device",
+				"pixel_8",
+			},
+			GetAvdManagerArguments(call.Request));
+	}
+
+	[Fact]
+	public async Task CreateAsync_RollsBackWithAnIndependentTokenWhenLookupIsCancelled()
+	{
+		using var sdk = new AndroidSdkFixture();
+		using var requestCancellation = new CancellationTokenSource();
+		var cleanupToken = CancellationToken.None;
+		var runner = new RecordingProcessRunner((request, token) =>
+		{
+			var arguments = GetAvdManagerArguments(request);
+			if (arguments.SequenceEqual(["list", "device", "-c"]))
+				return new ProcessResult(0, "pixel_8\n", "");
+
+			if (arguments.FirstOrDefault() == "create")
+			{
+				requestCancellation.Cancel();
+				return new ProcessResult(0, "", "");
+			}
+
+			if (arguments.FirstOrDefault() == "delete")
+			{
+				cleanupToken = token;
+				return new ProcessResult(0, "", "");
+			}
+
+			token.ThrowIfCancellationRequested();
+			throw new InvalidOperationException($"Unexpected process request: {request.FileName}");
+		});
+		await using var backend = new AndroidEmulatorBackend(
+			runner,
+			NullLogger<AndroidEmulatorBackend>.Instance,
+			new AndroidSdkLocator(sdk.Root));
+
+		var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			backend.CreateAsync(
+				new CreateDeviceRequest
+				{
+					Name = "cancelled lookup",
+					RuntimeId = sdk.RuntimeId,
+					DeviceTypeId = "pixel_8",
+				},
+				requestCancellation.Token));
+
+		Assert.Equal(requestCancellation.Token, exception.CancellationToken);
+		Assert.True(cleanupToken.CanBeCanceled);
+		Assert.False(cleanupToken.IsCancellationRequested);
+		Assert.NotEqual(requestCancellation.Token, cleanupToken);
+		Assert.Equal(
+			new[] { "delete", "avd", "--name", "cancelled_lookup" },
+			GetAvdManagerArguments(runner.Calls[^1].Request));
+	}
+
+	private static IReadOnlyList<string> GetAvdManagerArguments(ProcessRequest request)
+	{
+		if (request.Environment is null)
+			return request.Arguments;
+
+		return [.. request.Environment
+			.Where(pair => pair.Key.StartsWith("MOBILE_CANVAS_AVD_ARG_", StringComparison.Ordinal))
+			.OrderBy(pair => int.Parse(pair.Key["MOBILE_CANVAS_AVD_ARG_".Length..]))
+			.Select(pair => pair.Value!)];
+	}
+
+	private sealed class RecordingProcessRunner(
+		Func<ProcessRequest, CancellationToken, ProcessResult> run) : IProcessRunner
+	{
+		public List<(ProcessRequest Request, CancellationToken Token)> Calls { get; } = [];
+
+		public Task<ProcessResult> RunAsync(
+			ProcessRequest request,
+			CancellationToken cancellationToken = default)
+		{
+			Calls.Add((request, cancellationToken));
+			return Task.FromResult(run(request, cancellationToken));
+		}
+	}
+
+	private sealed class AndroidSdkFixture : IDisposable
+	{
+		public AndroidSdkFixture()
+		{
+			Root = Directory.CreateTempSubdirectory("mobile-canvas-sdk-").FullName;
+			CreateTool("platform-tools", Executable("adb"));
+			CreateTool("emulator", Executable("emulator"));
+			AvdManager = CreateTool("cmdline-tools", "latest", "bin", Script("avdmanager"));
+			Directory.CreateDirectory(Path.Combine(
+				Root,
+				"system-images",
+				"android-35",
+				"google_apis",
+				"arm64-v8a"));
+		}
+
+		public string Root { get; }
+		public string AvdManager { get; }
+		public string RuntimeId => "system-images;android-35;google_apis;arm64-v8a";
+
+		public void Dispose() => Directory.Delete(Root, recursive: true);
+
+		private string CreateTool(params string[] segments)
+		{
+			var path = Path.Combine([Root, .. segments]);
+			Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+			File.WriteAllText(path, "");
+			return path;
+		}
+
+		private static string Executable(string name) => OperatingSystem.IsWindows() ? name + ".exe" : name;
+
+		private static string Script(string name) => OperatingSystem.IsWindows() ? name + ".bat" : name;
+	}
 }

--- a/tests/MobileCanvas.Tests/CreationRollbackTests.cs
+++ b/tests/MobileCanvas.Tests/CreationRollbackTests.cs
@@ -1,0 +1,86 @@
+using MobileCanvas.Core;
+
+namespace MobileCanvas.Tests;
+
+public sealed class CreationRollbackTests
+{
+	[Fact]
+	public async Task ResolveAsync_DoesNotRollbackWhenResolutionSucceeds()
+	{
+		var rolledBack = false;
+
+		var result = await CreationRollback.ResolveAsync(
+			_ => Task.FromResult("resolved"),
+			_ =>
+			{
+				rolledBack = true;
+				return Task.CompletedTask;
+			},
+			"test resource");
+
+		Assert.Equal("resolved", result);
+		Assert.False(rolledBack);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_RollsBackAndPreservesTheResolutionFailure()
+	{
+		var expected = new InvalidOperationException("lookup failed");
+		var rolledBack = false;
+
+		var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			CreationRollback.ResolveAsync<string>(
+				_ => Task.FromException<string>(expected),
+				_ =>
+				{
+					rolledBack = true;
+					return Task.CompletedTask;
+				},
+				"test resource"));
+
+		Assert.Same(expected, actual);
+		Assert.True(rolledBack);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_UsesAnIndependentBoundedTokenAfterCancellation()
+	{
+		using var request = new CancellationTokenSource();
+		request.Cancel();
+		var cleanupToken = CancellationToken.None;
+
+		var actual = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			CreationRollback.ResolveAsync<string>(
+				token => Task.FromCanceled<string>(token),
+				token =>
+				{
+					cleanupToken = token;
+					return Task.CompletedTask;
+				},
+				"test resource",
+				request.Token));
+
+		Assert.Equal(request.Token, actual.CancellationToken);
+		Assert.True(cleanupToken.CanBeCanceled);
+		Assert.False(cleanupToken.IsCancellationRequested);
+		Assert.NotEqual(request.Token, cleanupToken);
+	}
+
+	[Fact]
+	public async Task ResolveAsync_ReportsResolutionAndRollbackFailures()
+	{
+		var resolution = new InvalidOperationException("lookup failed");
+		var rollback = new IOException("delete failed");
+
+		var actual = await Assert.ThrowsAsync<AggregateException>(() =>
+			CreationRollback.ResolveAsync<string>(
+				_ => Task.FromException<string>(resolution),
+				_ => Task.FromException(rollback),
+				"test resource"));
+
+		Assert.Equal(
+			"test resource was created but could not be resolved, and rollback also failed.",
+			actual.Message.Split(" (", StringSplitOptions.None)[0]);
+		Assert.Equal([resolution, rollback], actual.InnerExceptions);
+	}
+}


### PR DESCRIPTION
## Summary

- build on #91's platform-scoped availability checks, AVD-management probing, and safe cross-platform `avdmanager` invocation
- enumerate installed Android system images directly from the SDK, normalize runtime IDs to canonical package IDs, and ignore incomplete image directories
- prevent AVD creation from overwriting an existing device by removing `--force`, preserving normal collision failures, and rejecting uninstalled runtimes before launching `avdmanager`
- roll back newly created Android AVDs and iOS simulators when post-create lookup fails or is canceled, using an independent bounded cleanup token and preserving rollback failures
- add focused coverage for create arguments, sanitization, installed-image discovery, runtime validation, collision handling, and rollback behavior

## Validation

- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --filter 'FullyQualifiedName~AndroidEmulatorBackendTests|FullyQualifiedName~CreationRollbackTests|FullyQualifiedName~IosSimulatorBackendTests' --no-restore`

## Stack

This PR is stacked on #91 and targets `redth-android-emulator-guard`. The old runtime-manifest refresh commits were removed because those artifacts came from the previous #85-based lineage and would be stale after this restack.