### PR TITLE
Keep available mobile platforms usable without optional toolchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,21 @@ and take over at any time.
 
 | | Requirement |
 |---|---|
-| **iOS** | macOS and a full Xcode installation with Simulator runtimes |
-| **Android** | Android SDK with `emulator`, `avdmanager`, and `adb` on `PATH` |
+| **iOS** | macOS and a [full Xcode installation with Simulator runtimes](docs/ios-setup.md) |
+| **Android** | [Android SDK](docs/android-setup.md) with `emulator` and `adb`; `avdmanager` and Java are needed only to create or delete AVDs |
 | **Optional iOS fallbacks** | [`idb`](https://fbidb.io) (provides `idb_companion`), plus Screen Recording and Accessibility permission for ScreenCaptureKit window capture |
 
 The bundled `mobile-screencap` helper provides iOS touch, keyboard, buttons,
 rotation, accessibility hierarchy, and direct video capture. Xcode 26 uses
 Simulator.app; Xcode 27 uses Device Hub. Neither visible app needs to be open
 for headless input or hierarchy reads.
+
+Android-only workflows do not require Xcode. When Xcode is unavailable, Mobile
+Canvas keeps Android emulators usable and marks iOS as unavailable.
+
+Likewise, Java is not required to run or control existing Android emulators.
+It is used indirectly by `avdmanager` only when Mobile Canvas creates or deletes
+an AVD.
 
 Meta's `idb` metapackage is not required for `ui_tree`, `ui_find`, or `ui_tap`.
 It remains an optional compatibility input fallback and the final live-video

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,0 +1,49 @@
+# Set up Android Emulator support
+
+Mobile Canvas needs the Android SDK to discover, start, and control Android
+emulators. It does not require Xcode.
+
+## Install the required SDK packages
+
+The easiest setup is Android Studio. Open **Tools > SDK Manager** and install:
+
+- **Android SDK Platform-Tools**, which provides `adb`
+- **Android Emulator**, which provides the `emulator` executable
+- At least one Android system image and an AVD that uses it
+
+Set `ANDROID_HOME` or `ANDROID_SDK_ROOT` when the SDK is not installed in the
+platform's default location:
+
+```bash
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
+```
+
+On Windows or Linux, use the Android SDK location for that platform instead.
+
+Verify the required tools:
+
+```bash
+adb version
+emulator -version
+emulator -list-avds
+```
+
+## Creating and deleting AVDs
+
+Running and controlling an existing AVD only needs `adb` and `emulator`. Java is
+not a general Mobile Canvas requirement.
+
+Mobile Canvas uses `avdmanager` when it creates or deletes an AVD. For those
+operations, also install **Android SDK Command-line Tools (latest)** and make a
+compatible Java runtime available through `JAVA_HOME` or `PATH`. Android
+Studio's bundled runtime can be used when it is exposed to command-line tools.
+
+Verify the optional AVD-management path:
+
+```bash
+avdmanager list device -c
+```
+
+If this command reports that Java is missing, configure a JDK before creating
+or deleting AVDs. Existing emulators remain usable without `avdmanager`.

--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -1,0 +1,56 @@
+# Set up iOS Simulator support
+
+Mobile Canvas only needs Xcode when you want to use iOS Simulators. Android-only
+workflows can use Mobile Canvas without installing or configuring Xcode.
+
+## Install Xcode and a Simulator runtime
+
+1. Install the full Xcode application from the Mac App Store or
+   [Apple Developer downloads](https://developer.apple.com/download/all/).
+2. Open Xcode once and complete any license or component installation prompts.
+3. In **Xcode > Settings > Components**, install at least one iOS Simulator
+   runtime.
+
+Apple's standalone Command Line Tools package is not enough because it does not
+include CoreSimulator, Simulator.app, or Device Hub.
+
+## Select the full Xcode developer directory
+
+If Xcode is installed in `/Applications/Xcode.app`, select it system-wide:
+
+```bash
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+```
+
+To select Xcode only for the process that launches Mobile Canvas, set
+`DEVELOPER_DIR` instead:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+Verify that `simctl` is available and can list installed devices:
+
+```bash
+xcrun simctl list --json
+```
+
+If that command fails, confirm that the selected path belongs to the full Xcode
+application rather than `/Library/Developer/CommandLineTools`.
+
+## Optional accessibility and video fallbacks
+
+The bundled `mobile-screencap` helper provides the primary iOS input and video
+paths. Install Meta's `idb` package only when you need the accessibility
+hierarchy, compatibility input, or the final video fallback:
+
+```bash
+brew tap facebook/fb
+brew trust facebook/fb
+brew install facebook/fb/idb
+export IDB_COMPANION_PATH="$(brew --prefix idb-companion)/bin/idb_companion"
+```
+
+Screen Recording and Accessibility permissions are only required when Mobile
+Canvas must use its ScreenCaptureKit fallback. The canvas will offer direct
+links to the relevant macOS settings when those permissions are needed.

--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -3,82 +3,82 @@
     "darwin-arm64": {
       "rid": "osx-arm64",
       "executable": "mobile-canvas",
-      "id": "9511132796110868eca33d9ad540ef12e01c62fcc138f3192330334cf8ab3e04",
+      "id": "07d3c0bd2179ed7226b7677ad13f70607fe2d77812c1e70419d9839235206700",
       "files": {
         "mobile-canvas": {
-          "sha256": "9511132796110868eca33d9ad540ef12e01c62fcc138f3192330334cf8ab3e04",
-          "size": 32260640,
-          "asset": "mobile-canvas-v0.1.17-rc.3-osx-arm64.gz"
+          "sha256": "07d3c0bd2179ed7226b7677ad13f70607fe2d77812c1e70419d9839235206700",
+          "size": 32293808,
+          "asset": "mobile-canvas-v0.1.17-rc.4-osx-arm64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.17-rc.3-osx-arm64.gz"
+          "asset": "mobile-screencap-v0.1.17-rc.4-osx-arm64.gz"
         }
       }
     },
     "darwin-x64": {
       "rid": "osx-x64",
       "executable": "mobile-canvas",
-      "id": "e40e190629d10e6272e3465c74dcbd65b4c296e64438c47473b32a7f3b5104a2",
+      "id": "c03fdad4f692209a1adbbce8a4b6a9414b566c6d9c7b4fe56b3aeed3a97fdbc7",
       "files": {
         "mobile-canvas": {
-          "sha256": "e40e190629d10e6272e3465c74dcbd65b4c296e64438c47473b32a7f3b5104a2",
-          "size": 34008240,
-          "asset": "mobile-canvas-v0.1.17-rc.3-osx-x64.gz"
+          "sha256": "c03fdad4f692209a1adbbce8a4b6a9414b566c6d9c7b4fe56b3aeed3a97fdbc7",
+          "size": 34041144,
+          "asset": "mobile-canvas-v0.1.17-rc.4-osx-x64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.17-rc.3-osx-x64.gz"
+          "asset": "mobile-screencap-v0.1.17-rc.4-osx-x64.gz"
         }
       }
     },
     "linux-arm64": {
       "rid": "linux-arm64",
       "executable": "mobile-canvas",
-      "id": "1b3b7f913b796fa217738ff714c1c979ddead9db0a4b04e793c2da6ac2fb669a",
+      "id": "82a033e519d287e76fa91b5eb62a08a4cb81658e9daa2da759e0d0492f3ec428",
       "files": {
         "mobile-canvas": {
-          "sha256": "1b3b7f913b796fa217738ff714c1c979ddead9db0a4b04e793c2da6ac2fb669a",
-          "size": 34417304,
-          "asset": "mobile-canvas-v0.1.17-rc.3-linux-arm64.gz"
+          "sha256": "82a033e519d287e76fa91b5eb62a08a4cb81658e9daa2da759e0d0492f3ec428",
+          "size": 34417856,
+          "asset": "mobile-canvas-v0.1.17-rc.4-linux-arm64.gz"
         }
       }
     },
     "linux-x64": {
       "rid": "linux-x64",
       "executable": "mobile-canvas",
-      "id": "ebde13fcd38f071a162fec9a729cab1ea0c2265ffbe447f96467a781c3841828",
+      "id": "5e3dd43058df1bf082e60418556a972964d3f086c36ed02119868ce8d4660ca7",
       "files": {
         "mobile-canvas": {
-          "sha256": "ebde13fcd38f071a162fec9a729cab1ea0c2265ffbe447f96467a781c3841828",
-          "size": 33671616,
-          "asset": "mobile-canvas-v0.1.17-rc.3-linux-x64.gz"
+          "sha256": "5e3dd43058df1bf082e60418556a972964d3f086c36ed02119868ce8d4660ca7",
+          "size": 33709008,
+          "asset": "mobile-canvas-v0.1.17-rc.4-linux-x64.gz"
         }
       }
     },
     "win32-arm64": {
       "rid": "win-arm64",
       "executable": "mobile-canvas.exe",
-      "id": "7c279939de15c42e651abc41949b00ee694ae0953fdeb1fed10aa662fed88237",
+      "id": "f8db6c1de6c6a8bc3c311182375ed7996c59e8244d53adedf5382a229f31feaa",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "7c279939de15c42e651abc41949b00ee694ae0953fdeb1fed10aa662fed88237",
-          "size": 37993472,
-          "asset": "mobile-canvas-v0.1.17-rc.3-win-arm64.gz"
+          "sha256": "f8db6c1de6c6a8bc3c311182375ed7996c59e8244d53adedf5382a229f31feaa",
+          "size": 38033920,
+          "asset": "mobile-canvas-v0.1.17-rc.4-win-arm64.gz"
         }
       }
     },
     "win32-x64": {
       "rid": "win-x64",
       "executable": "mobile-canvas.exe",
-      "id": "24986d9b0fba6be11b266e966a82c4241540c4345f97883921b2fcc208e3dccb",
+      "id": "225cbd6a670d2716a07a5cecd0d16a35f756502589b3e24282e3fc4d0f675086",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "24986d9b0fba6be11b266e966a82c4241540c4345f97883921b2fcc208e3dccb",
-          "size": 37298688,
-          "asset": "mobile-canvas-v0.1.17-rc.3-win-x64.gz"
+          "sha256": "225cbd6a670d2716a07a5cecd0d16a35f756502589b3e24282e3fc4d0f675086",
+          "size": 37337088,
+          "asset": "mobile-canvas-v0.1.17-rc.4-win-x64.gz"
         }
       }
     }
@@ -86,7 +86,7 @@
   "version": "0.1.17",
   "distribution": {
     "repository": "Redth/mobile-canvas-ghcp",
-    "tag": "v0.1.17-rc.3"
+    "tag": "v0.1.17-rc.4"
   },
-  "sourceHash": "f48eaccbe82f2ba1b5eef593a6a69ee402ec54a3418808a1d71c82495866862c"
+  "sourceHash": "30f2323c84363778ee5a84b370339b8e3d2bbc7cb43ed433879fabcebb2e68c5"
 }

--- a/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
+++ b/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
@@ -26,6 +26,9 @@ namespace MobileCanvas.Android;
 public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDisposable
 {
 	private const string ProviderId = "android-emulator";
+	private const string AndroidSetupUrl =
+		"https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/android-setup.md";
+	private static readonly string[] RequiredSdkChecks = ["android-sdk", "adb", "emulator"];
 
 	private readonly AndroidSdkLocator _locator = new();
 	private readonly EmulatorConnectionPool _connections = new();
@@ -33,6 +36,9 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	private readonly IProcessRunner _processRunner;
 	private readonly ILogger<AndroidEmulatorBackend> _logger;
 	private readonly AndroidRecordingManager _recordings;
+	private readonly SemaphoreSlim _avdManagerProbeGate = new(1, 1);
+	private AvdManagerProbe? _avdManagerProbe;
+	private volatile bool _avdManagementReady;
 
 	// Running-instance cache. Reading discovery files is a handful of file reads rather than a
 	// process spawn, but the iOS work proved that anything on the per-event path needs a cache, and
@@ -66,39 +72,88 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	public string Platform => DevicePlatforms.Android;
 
 	private sealed record CachedInstance(EmulatorInstance Instance, long Timestamp);
+	private sealed record AvdManagerProbe(
+		bool Ready,
+		DeviceType[] DeviceTypes,
+		DependencyCheck Check);
 
 	#region Catalog
 
 	public async Task<DeviceCatalog> GetCatalogAsync(CancellationToken cancellationToken = default)
 	{
 		var checks = _locator.Check();
+		if (!HasRequiredSdkTools(checks))
+		{
+			return new DeviceCatalog
+			{
+				Diagnostics = [BuildAndroidUnavailableDiagnostics()],
+			};
+		}
+
+		var avdManager = await GetAvdManagerProbeAsync(
+			force: true,
+			cancellationToken).ConfigureAwait(false);
+		_avdManagementReady = avdManager.Ready;
+		checks = [.. checks.Select(check =>
+			check.Name.Equals("avdmanager", StringComparison.OrdinalIgnoreCase)
+				? avdManager.Check
+				: check)];
+
 		var diagnostics = new HostDiagnostics
 		{
 			Platform = DevicePlatforms.Android,
-			Ready = checks.All(c => c.Status != "missing" && c.Status != "error"),
+			Ready = true,
 			Checks = checks,
 		};
 
-		if (!diagnostics.Ready)
-			return new DeviceCatalog { Diagnostics = [diagnostics] };
-
 		var devices = await ListDevicesCoreAsync(cancellationToken).ConfigureAwait(false);
-		var deviceTypes = await ListDeviceTypesAsync(cancellationToken).ConfigureAwait(false);
 
 		return new DeviceCatalog
 		{
 			Devices = devices,
 			Runtimes = BuildRuntimes(devices),
-			DeviceTypes = deviceTypes,
+			DeviceTypes = avdManager.DeviceTypes,
 			Diagnostics = [diagnostics],
 		};
 	}
+
+	internal static bool HasRequiredSdkTools(IReadOnlyList<DependencyCheck> checks) =>
+		RequiredSdkChecks.All(required => checks.Any(
+			check => check.Name.Equals(required, StringComparison.OrdinalIgnoreCase)
+				&& check.Status.Equals("ok", StringComparison.OrdinalIgnoreCase)));
+
+	internal static HostDiagnostics BuildAndroidUnavailableDiagnostics() =>
+		new()
+		{
+			Platform = DevicePlatforms.Android,
+			Available = false,
+			Ready = false,
+			Checks =
+			[
+				new DependencyCheck
+				{
+					Name = "Android",
+					Status = "error",
+					Message = "Android requires the Android SDK.",
+					Actions =
+					[
+						new DiagnosticAction
+						{
+							Type = DiagnosticActionTypes.OpenUrl,
+							Target = AndroidSetupUrl,
+							Label = "Learn more",
+						},
+					],
+				},
+			],
+		};
 
 	public async Task<DeviceTarget[]> ListDevicesAsync(CancellationToken cancellationToken = default)
 	{
 		if (_locator.Emulator is null)
 			return [];
 
+		await GetAvdManagerProbeAsync(force: false, cancellationToken).ConfigureAwait(false);
 		return await ListDevicesCoreAsync(cancellationToken).ConfigureAwait(false);
 	}
 
@@ -145,6 +200,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 
 	public async Task<DeviceTarget> GetDeviceAsync(string deviceId, CancellationToken cancellationToken = default)
 	{
+		await GetAvdManagerProbeAsync(force: false, cancellationToken).ConfigureAwait(false);
 		var devices = await ListDevicesCoreAsync(cancellationToken).ConfigureAwait(false);
 		return devices.FirstOrDefault(d => string.Equals(d.Id, deviceId, StringComparison.OrdinalIgnoreCase))
 			?? throw new DeviceNotFoundException(deviceId);
@@ -199,7 +255,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	/// without gRPC genuinely cannot stream or take low-latency input. Reporting it honestly lets the
 	/// canvas explain the restart instead of presenting a dead viewport.
 	/// </summary>
-	private static DeviceCapabilities BuildCapabilities(EmulatorInstance? instance)
+	private DeviceCapabilities BuildCapabilities(EmulatorInstance? instance)
 	{
 		var grpc = instance?.HasGrpc == true;
 		return new DeviceCapabilities
@@ -208,7 +264,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 			Shutdown = true,
 			Restart = true,
 			Erase = true,
-			Delete = true,
+			Delete = _avdManagementReady,
 			Reveal = true,
 			Tap = true,
 			LongPress = true,
@@ -245,21 +301,57 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 			.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)];
 	}
 
-	private async Task<DeviceType[]> ListDeviceTypesAsync(CancellationToken cancellationToken)
+	private async Task<AvdManagerProbe> GetAvdManagerProbeAsync(
+		bool force,
+		CancellationToken cancellationToken)
+	{
+		if (!force && _avdManagerProbe is not null)
+			return _avdManagerProbe;
+
+		await _avdManagerProbeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			if (!force && _avdManagerProbe is not null)
+				return _avdManagerProbe;
+
+			var probe = await ProbeAvdManagerAsync(cancellationToken).ConfigureAwait(false);
+			_avdManagerProbe = probe;
+			_avdManagementReady = probe.Ready;
+			return probe;
+		}
+		finally
+		{
+			_avdManagerProbeGate.Release();
+		}
+	}
+
+	private async Task<AvdManagerProbe> ProbeAvdManagerAsync(CancellationToken cancellationToken)
 	{
 		if (_locator.AvdManager is null)
-			return [];
+		{
+			return new AvdManagerProbe(
+				false,
+				[],
+				BuildAvdManagerUnavailableCheck());
+		}
 
 		try
 		{
 			var result = await _processRunner
-				.RunAsync(new ProcessRequest(_locator.AvdManager, ["list", "device", "-c"]), cancellationToken)
+				.RunAsync(
+					_locator.CreateAvdManagerRequest(["list", "device", "-c"]),
+					cancellationToken)
 				.ConfigureAwait(false);
 
 			if (result.ExitCode != 0)
-				return [];
+			{
+				return new AvdManagerProbe(
+					false,
+					[],
+					BuildAvdManagerUnavailableCheck(_locator.AvdManager));
+			}
 
-			return [.. result.StandardOutput
+			DeviceType[] deviceTypes = [.. result.StandardOutput
 				.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
 				.Where(static line => line.Length > 0 && line[0] != '[' && !line.Contains(':', StringComparison.Ordinal))
 				.Distinct(StringComparer.OrdinalIgnoreCase)
@@ -270,12 +362,45 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 					Platform = DevicePlatforms.Android,
 					ProductFamily = DevicePlatforms.Android,
 				})];
+			return new AvdManagerProbe(
+				true,
+				deviceTypes,
+				new DependencyCheck
+				{
+					Name = "avdmanager",
+					Status = "ok",
+					Message = "avdmanager and Java are available.",
+					Path = _locator.AvdManager,
+				});
 		}
 		catch (Exception exception) when (exception is not OperationCanceledException)
 		{
 			_logger.LogDebug(exception, "Failed to enumerate Android device types.");
-			return [];
+			return new AvdManagerProbe(
+				false,
+				[],
+				BuildAvdManagerUnavailableCheck(_locator.AvdManager));
 		}
+	}
+
+	internal static DependencyCheck BuildAvdManagerUnavailableCheck(string? path = null) =>
+		new()
+		{
+			Name = "avdmanager",
+			Status = "warning",
+			Message = "AVD management requires cmdline-tools and a working Java runtime. "
+				+ "Existing emulators remain available.",
+			Path = path,
+		};
+
+	private async Task<string> RequireAvdManagerAsync(CancellationToken cancellationToken)
+	{
+		var probe = await GetAvdManagerProbeAsync(
+			force: true,
+			cancellationToken).ConfigureAwait(false);
+		return probe.Ready
+			? _locator.AvdManager!
+			: throw new DeviceCapabilityException(probe.Check.Message);
 	}
 
 	#endregion
@@ -286,16 +411,11 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		CreateDeviceRequest request,
 		CancellationToken cancellationToken = default)
 	{
-		if (_locator.AvdManager is null)
-		{
-			throw new DeviceCapabilityException(
-				"avdmanager was not found. Install the Android SDK 'cmdline-tools;latest' package to create AVDs.");
-		}
-
 		if (string.IsNullOrWhiteSpace(request.RuntimeId))
 			throw new ArgumentException("A system image (runtimeId) is required to create an AVD.", nameof(request));
 
 		var name = SanitizeAvdName(request.Name);
+		var avdManager = await RequireAvdManagerAsync(cancellationToken).ConfigureAwait(false);
 		var arguments = new List<string>
 		{
 			"create", "avd", "--name", name, "--package", request.RuntimeId, "--force",
@@ -309,11 +429,13 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 
 		// avdmanager prompts on stdin for a custom hardware profile; "no" accepts the image default.
 		var result = await _processRunner
-			.RunAsync(new ProcessRequest(_locator.AvdManager, [.. arguments], StandardInput: "no\n"), cancellationToken)
+			.RunAsync(
+				_locator.CreateAvdManagerRequest([.. arguments], standardInput: "no\n"),
+				cancellationToken)
 			.ConfigureAwait(false);
 
 		if (result.ExitCode != 0)
-			throw new ProcessExecutionException(_locator.AvdManager, arguments, result);
+			throw new ProcessExecutionException(avdManager, arguments, result);
 
 		return await GetDeviceAsync(
 			DeviceIdentity.Create(Platform, ProviderId, name),
@@ -565,22 +687,17 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 
 	public async Task DeleteAsync(string deviceId, CancellationToken cancellationToken = default)
 	{
-		if (_locator.AvdManager is null)
-		{
-			throw new DeviceCapabilityException(
-				"avdmanager was not found. Install the Android SDK 'cmdline-tools;latest' package to delete AVDs.");
-		}
-
+		var avdManager = await RequireAvdManagerAsync(cancellationToken).ConfigureAwait(false);
 		var avdId = DeviceIdentity.GetNativeId(deviceId);
 		await ShutdownAsync(deviceId, cancellationToken).ConfigureAwait(false);
 
 		var arguments = new[] { "delete", "avd", "--name", avdId };
 		var result = await _processRunner
-			.RunAsync(new ProcessRequest(_locator.AvdManager, arguments), cancellationToken)
+			.RunAsync(_locator.CreateAvdManagerRequest(arguments), cancellationToken)
 			.ConfigureAwait(false);
 
 		if (result.ExitCode != 0)
-			throw new ProcessExecutionException(_locator.AvdManager, arguments, result);
+			throw new ProcessExecutionException(avdManager, arguments, result);
 
 		InvalidateCache(avdId);
 	}
@@ -3726,6 +3843,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	{
 		await _recordings.DisposeAsync().ConfigureAwait(false);
 		await _connections.DisposeAsync().ConfigureAwait(false);
+		_avdManagerProbeGate.Dispose();
 		_cacheGate.Dispose();
 	}
 }

--- a/src/MobileCanvas.Android/AndroidSdkLocator.cs
+++ b/src/MobileCanvas.Android/AndroidSdkLocator.cs
@@ -91,7 +91,20 @@ internal sealed class AndroidSdkLocator
 
 		checks.Add(Tool("adb", Adb, "adb not found. Install platform-tools."));
 		checks.Add(Tool("emulator", Emulator, "emulator not found. Install the Android Emulator package."));
-		checks.Add(Tool("avdmanager", AvdManager, "avdmanager not found. Install cmdline-tools; creating AVDs will be unavailable."));
+		checks.Add(AvdManager is null
+			? new DependencyCheck
+			{
+				Name = "avdmanager",
+				Status = "warning",
+				Message = "avdmanager not found. Install cmdline-tools to create or delete AVDs.",
+			}
+			: new DependencyCheck
+			{
+				Name = "avdmanager",
+				Status = "ok",
+				Message = "avdmanager found.",
+				Path = AvdManager,
+			});
 
 		return [.. checks];
 
@@ -99,6 +112,60 @@ internal sealed class AndroidSdkLocator
 			path is null
 				? new DependencyCheck { Name = name, Status = "missing", Message = missingMessage }
 				: new DependencyCheck { Name = name, Status = "ok", Message = $"{name} found.", Path = path };
+	}
+
+	public ProcessRequest CreateAvdManagerRequest(
+		IReadOnlyList<string> arguments,
+		string? standardInput = null)
+	{
+		var avdManager = AvdManager
+			?? throw new InvalidOperationException("avdmanager was not found.");
+		return BuildAvdManagerRequest(
+			avdManager,
+			arguments,
+			standardInput,
+			RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+	}
+
+	internal static ProcessRequest BuildAvdManagerRequest(
+		string avdManager,
+		IReadOnlyList<string> arguments,
+		string? standardInput,
+		bool windows)
+	{
+		if (!windows)
+			return new ProcessRequest(avdManager, arguments, standardInput);
+
+		ValidateCmdValue(avdManager, nameof(avdManager));
+		var environment = new Dictionary<string, string?>
+		{
+			["MOBILE_CANVAS_AVDMANAGER"] = avdManager,
+		};
+		var command = "\"%MOBILE_CANVAS_AVDMANAGER%\"";
+		for (var index = 0; index < arguments.Count; index++)
+		{
+			ValidateCmdValue(arguments[index], nameof(arguments));
+			var name = $"MOBILE_CANVAS_AVD_ARG_{index}";
+			environment[name] = arguments[index];
+			command += $" \"%{name}%\"";
+		}
+
+		return new ProcessRequest(
+			"cmd.exe",
+			[],
+			standardInput,
+			environment,
+			RawArguments: $"/d /v:off /s /c \"{command}\"");
+	}
+
+	private static void ValidateCmdValue(string value, string parameterName)
+	{
+		if (value.IndexOfAny(['\0', '\r', '\n', '"', '%', '!', '&', '|', '<', '>', '^']) >= 0)
+		{
+			throw new ArgumentException(
+				"avdmanager paths and arguments cannot contain Windows command-shell metacharacters.",
+				parameterName);
+		}
 	}
 
 	private string? Resolve(string relativePath)

--- a/src/MobileCanvas.Contracts/DeviceContracts.cs
+++ b/src/MobileCanvas.Contracts/DeviceContracts.cs
@@ -129,6 +129,7 @@ public sealed record DeviceType
 public static class DiagnosticActionTypes
 {
 	public const string OpenSystemSettings = "open-system-settings";
+	public const string OpenUrl = "open-url";
 }
 
 public static class SystemSettingsTargets
@@ -157,6 +158,7 @@ public sealed record DependencyCheck
 public sealed record HostDiagnostics
 {
 	public string Platform { get; init; } = "";
+	public bool Available { get; init; } = true;
 	public bool Ready { get; init; }
 	public DependencyCheck[] Checks { get; init; } = [];
 }

--- a/src/MobileCanvas.Core/ProcessRunner.cs
+++ b/src/MobileCanvas.Core/ProcessRunner.cs
@@ -7,7 +7,8 @@ public sealed record ProcessRequest(
 	IReadOnlyList<string> Arguments,
 	string? StandardInput = null,
 	IReadOnlyDictionary<string, string?>? Environment = null,
-	string? WorkingDirectory = null);
+	string? WorkingDirectory = null,
+	string? RawArguments = null);
 
 public sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
 
@@ -50,8 +51,17 @@ public sealed class SystemProcessRunner : IProcessRunner
 			WorkingDirectory = request.WorkingDirectory ?? "",
 		};
 
-		foreach (var argument in request.Arguments)
-			startInfo.ArgumentList.Add(argument);
+		if (request.RawArguments is not null)
+		{
+			if (request.Arguments.Count > 0)
+				throw new ArgumentException("Raw process arguments cannot be combined with ArgumentList entries.");
+			startInfo.Arguments = request.RawArguments;
+		}
+		else
+		{
+			foreach (var argument in request.Arguments)
+				startInfo.ArgumentList.Add(argument);
+		}
 
 		if (request.Environment is not null)
 		{

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -10,7 +10,11 @@ namespace MobileCanvas.iOS;
 
 public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 {
+	private const string IosSetupUrl =
+		"https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/ios-setup.md";
+
 	private readonly IProcessRunner _processRunner;
+	private readonly Func<CancellationToken, Task<string>> _resolveDeveloperDirectory;
 	private readonly CoreSimulatorHidManager _hid;
 	private readonly IdbCompanionManager _companions;
 	private readonly NativeAccessibilityReader _accessibility;
@@ -34,8 +38,20 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	private static readonly TimeSpan BootedCacheLifetime = TimeSpan.FromSeconds(15);
 
 	public IosSimulatorBackend(IProcessRunner processRunner)
+		: this(
+			processRunner,
+			cancellationToken => XcodeDeveloperDirectory.ResolveSelectedAsync(
+				processRunner,
+				cancellationToken))
+	{
+	}
+
+	internal IosSimulatorBackend(
+		IProcessRunner processRunner,
+		Func<CancellationToken, Task<string>> resolveDeveloperDirectory)
 	{
 		_processRunner = processRunner;
+		_resolveDeveloperDirectory = resolveDeveloperDirectory;
 		_hid = new CoreSimulatorHidManager();
 		_companions = new IdbCompanionManager(processRunner);
 		_accessibility = new NativeAccessibilityReader(processRunner);
@@ -56,6 +72,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 					new HostDiagnostics
 					{
 						Platform = DevicePlatforms.Ios,
+						Available = false,
 						Ready = false,
 						Checks =
 						[
@@ -71,13 +88,25 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			};
 		}
 
-		var result = await RunAsync(["list", "--json"], cancellationToken).ConfigureAwait(false);
-		EnsureSuccess("xcrun", ["simctl", "list", "--json"], result);
+		var xcodePath = await TryResolveFullXcodeAsync(cancellationToken).ConfigureAwait(false);
+		if (xcodePath is null)
+			return new DeviceCatalog { Diagnostics = [BuildXcodeUnavailableDiagnostics()] };
+
+		ProcessResult result;
+		try
+		{
+			result = await RunAsync(["list", "--json"], cancellationToken).ConfigureAwait(false);
+			EnsureSuccess("xcrun", ["simctl", "list", "--json"], result);
+		}
+		catch (ProcessExecutionException)
+		{
+			return new DeviceCatalog { Diagnostics = [BuildSimctlUnavailableDiagnostics()] };
+		}
 		var catalog = SimctlCatalogParser.Parse(result.StandardOutput);
 		RefreshBootedCache(catalog.Devices);
 		return catalog with
 		{
-			Diagnostics = [await GetDiagnosticsAsync(cancellationToken).ConfigureAwait(false)],
+			Diagnostics = [await GetDiagnosticsAsync(xcodePath, cancellationToken).ConfigureAwait(false)],
 		};
 	}
 
@@ -2466,16 +2495,14 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			new ProcessRequest("xcrun", ["simctl", .. arguments]),
 			cancellationToken);
 
-	private async Task<HostDiagnostics> GetDiagnosticsAsync(CancellationToken cancellationToken)
+	private async Task<string?> TryResolveFullXcodeAsync(CancellationToken cancellationToken)
 	{
-		var checks = new List<DependencyCheck>();
-		string? xcodePath = null;
-		string? xcodeFailure = null;
 		try
 		{
-			xcodePath = await XcodeDeveloperDirectory.ResolveSelectedAsync(
-				_processRunner,
-				cancellationToken).ConfigureAwait(false);
+			var developerDirectory = await _resolveDeveloperDirectory(cancellationToken).ConfigureAwait(false);
+			return SimulatorHostLocator.TryResolve(developerDirectory, out _)
+				? developerDirectory
+				: null;
 		}
 		catch (OperationCanceledException)
 		{
@@ -2484,21 +2511,77 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		catch (Exception exception) when (
 			exception is ProcessExecutionException
 				or InvalidOperationException
-				or ArgumentException)
+				or ArgumentException
+				or IOException
+				or UnauthorizedAccessException)
 		{
-			xcodeFailure = exception.Message;
+			return null;
 		}
-		var xcodeReady = !string.IsNullOrWhiteSpace(xcodePath);
+	}
+
+	internal static HostDiagnostics BuildXcodeUnavailableDiagnostics() =>
+		new()
+		{
+			Platform = DevicePlatforms.Ios,
+			Available = false,
+			Ready = false,
+			Checks =
+			[
+				new DependencyCheck
+				{
+					Name = "iOS",
+					Status = "error",
+					Message = "iOS requires Xcode.",
+					Actions =
+					[
+						new DiagnosticAction
+						{
+							Type = DiagnosticActionTypes.OpenUrl,
+							Target = IosSetupUrl,
+							Label = "Learn more",
+						},
+					],
+				},
+			],
+		};
+
+	internal static HostDiagnostics BuildSimctlUnavailableDiagnostics() =>
+		new()
+		{
+			Platform = DevicePlatforms.Ios,
+			Available = false,
+			Ready = false,
+			Checks =
+			[
+				new DependencyCheck
+				{
+					Name = "iOS",
+					Status = "error",
+					Message = "iOS Simulator is unavailable.",
+					Actions =
+					[
+						new DiagnosticAction
+						{
+							Type = DiagnosticActionTypes.OpenUrl,
+							Target = IosSetupUrl,
+							Label = "Learn more",
+						},
+					],
+				},
+			],
+		};
+
+	private async Task<HostDiagnostics> GetDiagnosticsAsync(
+		string xcodePath,
+		CancellationToken cancellationToken)
+	{
+		var checks = new List<DependencyCheck>();
 		var companion = IdbCompanionLocator.Find();
 		checks.Add(new DependencyCheck
 		{
 			Name = "Xcode",
-			Status = xcodeReady ? "ok" : "error",
-			Message = xcodeReady
-				? "Full Xcode developer directory is selected."
-				: string.IsNullOrWhiteSpace(xcodeFailure)
-					? "xcode-select did not return a developer directory."
-					: xcodeFailure,
+			Status = "ok",
+			Message = "Full Xcode developer directory is selected.",
 			Path = xcodePath,
 		});
 
@@ -2510,8 +2593,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		checks.Add(BuildHidCheck(hid, companion));
 
 		SimulatorKitInstallation? simulatorKit = null;
-		if (xcodeReady)
-			SimulatorKitLocator.TryResolve(xcodePath!, out simulatorKit);
+		SimulatorKitLocator.TryResolve(xcodePath, out simulatorKit);
 		var simulatorKitRequired = string.Equals(
 			hid.TransportPolicy,
 			"indigo",
@@ -2525,9 +2607,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 					? "error"
 					: "warning",
 			Message = simulatorKit is null
-				? xcodeReady
-					? SimulatorKitLocator.GetMissingFrameworkMessage(xcodePath!)
-					: "Select a full Xcode installation before checking SimulatorKit.framework."
+				? SimulatorKitLocator.GetMissingFrameworkMessage(xcodePath)
 				: simulatorKit.Layout == SimulatorKitLayout.SharedFrameworks
 					? "Xcode 27 shared-framework layout is available for HID interactions."
 					: "Legacy Xcode private-framework layout is available for HID interactions.",
@@ -2562,7 +2642,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		return new HostDiagnostics
 		{
 			Platform = DevicePlatforms.Ios,
-			Ready = xcodeReady && (nativeHidReady || companion is not null),
+			Ready = nativeHidReady || companion is not null,
 			Checks = checks.ToArray(),
 		};
 	}

--- a/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
@@ -1,4 +1,6 @@
 using MobileCanvas.Android;
+using MobileCanvas.Contracts;
+using MobileCanvas.Core;
 
 namespace MobileCanvas.Tests;
 
@@ -27,4 +29,122 @@ public sealed class AndroidEmulatorBackendTests
 
 		Assert.DoesNotContain("-no-window", arguments);
 	}
+
+	[Fact]
+	public void RequiredSdkTools_DoNotRequireAvdManagerOrJava()
+	{
+		var checks = new[]
+		{
+			Check("android-sdk", "ok"),
+			Check("adb", "ok"),
+			Check("emulator", "ok"),
+			Check("avdmanager", "warning"),
+			Check("java", "warning"),
+		};
+
+		Assert.True(AndroidEmulatorBackend.HasRequiredSdkTools(checks));
+	}
+
+	[Fact]
+	public void RequiredSdkTools_RejectAMissingRuntimeTool()
+	{
+		var checks = new[]
+		{
+			Check("android-sdk", "ok"),
+			Check("adb", "missing"),
+			Check("emulator", "ok"),
+			Check("avdmanager", "ok"),
+		};
+
+		Assert.False(AndroidEmulatorBackend.HasRequiredSdkTools(checks));
+	}
+
+	[Fact]
+	public void MissingAndroidSdkDiagnostic_IsConciseAndLinksToTheSetupGuide()
+	{
+		var diagnostics = AndroidEmulatorBackend.BuildAndroidUnavailableDiagnostics();
+		var check = Assert.Single(diagnostics.Checks);
+		var action = Assert.Single(check.Actions);
+
+		Assert.False(diagnostics.Ready);
+		Assert.False(diagnostics.Available);
+		Assert.Equal(DevicePlatforms.Android, diagnostics.Platform);
+		Assert.Equal("Android requires the Android SDK.", check.Message);
+		Assert.Equal(DiagnosticActionTypes.OpenUrl, action.Type);
+		Assert.Equal("Learn more", action.Label);
+		Assert.Equal(
+			"https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/android-setup.md",
+			action.Target);
+	}
+
+	[Fact]
+	public void UnavailableAvdManagement_DoesNotDisableExistingEmulators()
+	{
+		var check = AndroidEmulatorBackend.BuildAvdManagerUnavailableCheck();
+
+		Assert.Equal("warning", check.Status);
+		Assert.Contains("Java runtime", check.Message, StringComparison.Ordinal);
+		Assert.Contains("Existing emulators remain available", check.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void WindowsAvdManager_UsesCmdWithArgumentsInTheEnvironment()
+	{
+		var request = AndroidSdkLocator.BuildAvdManagerRequest(
+			@"C:\Android SDK\cmdline-tools\latest\bin\avdmanager.bat",
+			["create", "avd", "--name", "Test_Device"],
+			"no\n",
+			windows: true);
+
+		Assert.Equal("cmd.exe", request.FileName);
+		Assert.Empty(request.Arguments);
+		Assert.Equal(
+			"/d /v:off /s /c \"\"%MOBILE_CANVAS_AVDMANAGER%\" "
+				+ "\"%MOBILE_CANVAS_AVD_ARG_0%\" \"%MOBILE_CANVAS_AVD_ARG_1%\" "
+				+ "\"%MOBILE_CANVAS_AVD_ARG_2%\" \"%MOBILE_CANVAS_AVD_ARG_3%\"\"",
+			request.RawArguments);
+		Assert.Equal("Test_Device", request.Environment!["MOBILE_CANVAS_AVD_ARG_3"]);
+		Assert.Equal("no\n", request.StandardInput);
+	}
+
+	[Fact]
+	public void WindowsAvdManager_RejectsCommandShellMetacharacters()
+	{
+		Assert.Throws<ArgumentException>(() => AndroidSdkLocator.BuildAvdManagerRequest(
+			@"C:\Android\avdmanager.bat",
+			["create", "avd", "--name", "unsafe&command"],
+			null,
+			windows: true));
+	}
+
+	[Fact]
+	public async Task WindowsAvdManagerRequest_ExecutesBatchFile()
+	{
+		if (!OperatingSystem.IsWindows())
+			return;
+
+		var directory = Directory.CreateTempSubdirectory("mobile-canvas-avdmanager-");
+		try
+		{
+			var script = Path.Combine(directory.FullName, "avdmanager.bat");
+			await File.WriteAllTextAsync(script, "@echo off\r\necho %~1^|%~2\r\n");
+			var request = AndroidSdkLocator.BuildAvdManagerRequest(
+				script,
+				["hello", "world"],
+				null,
+				windows: true);
+
+			var result = await new SystemProcessRunner().RunAsync(request);
+
+			Assert.Equal(0, result.ExitCode);
+			Assert.Equal("hello|world", result.StandardOutput.Trim());
+		}
+		finally
+		{
+			directory.Delete(recursive: true);
+		}
+	}
+
+	private static DependencyCheck Check(string name, string status) =>
+		new() { Name = name, Status = status };
 }

--- a/tests/MobileCanvas.Tests/IosSimulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/IosSimulatorBackendTests.cs
@@ -1,0 +1,167 @@
+using MobileCanvas.Contracts;
+using MobileCanvas.Core;
+using MobileCanvas.iOS;
+
+namespace MobileCanvas.Tests;
+
+public sealed class IosSimulatorBackendTests
+{
+	private const string CatalogJson = """
+		{
+		  "runtimes": [{
+		    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+		    "name": "iOS 18.6",
+		    "version": "18.6",
+		    "isAvailable": true
+		  }],
+		  "devicetypes": [{
+		    "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+		    "name": "iPhone 16 Pro"
+		  }],
+		  "devices": {
+		    "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [{
+		      "name": "Test iPhone",
+		      "udid": "ABCD-1234",
+		      "state": "Shutdown",
+		      "isAvailable": true,
+		      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"
+		    }]
+		  }
+		}
+		""";
+
+	[Fact]
+	public void MissingXcodeDiagnostic_IsConciseAndLinksToTheSetupGuide()
+	{
+		var diagnostics = IosSimulatorBackend.BuildXcodeUnavailableDiagnostics();
+		var check = Assert.Single(diagnostics.Checks);
+		var action = Assert.Single(check.Actions);
+
+		Assert.False(diagnostics.Ready);
+		Assert.False(diagnostics.Available);
+		Assert.Equal(DevicePlatforms.Ios, diagnostics.Platform);
+		Assert.Equal("iOS requires Xcode.", check.Message);
+		Assert.Equal(DiagnosticActionTypes.OpenUrl, action.Type);
+		Assert.Equal("Learn more", action.Label);
+		Assert.Equal(
+			"https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/ios-setup.md",
+			action.Target);
+	}
+
+	[Fact]
+	public void SimctlFailureDiagnostic_IsNonFatalAndLinksToTheSetupGuide()
+	{
+		var diagnostics = IosSimulatorBackend.BuildSimctlUnavailableDiagnostics();
+		var check = Assert.Single(diagnostics.Checks);
+
+		Assert.False(diagnostics.Available);
+		Assert.False(diagnostics.Ready);
+		Assert.Equal("iOS Simulator is unavailable.", check.Message);
+		Assert.Equal(DiagnosticActionTypes.OpenUrl, Assert.Single(check.Actions).Type);
+	}
+
+	[Fact]
+	public async Task GetCatalogAsync_WithoutFullXcode_DoesNotInvokeSimctl()
+	{
+		if (!OperatingSystem.IsMacOS())
+			return;
+
+		var commandLineTools = Directory.CreateTempSubdirectory("mobile-canvas-command-line-tools-");
+		try
+		{
+			var runner = new RecordingProcessRunner();
+			await using var backend = new IosSimulatorBackend(
+				runner,
+				_ => Task.FromResult(commandLineTools.FullName));
+
+			var catalog = await backend.GetCatalogAsync();
+
+			Assert.Empty(catalog.Devices);
+			Assert.Empty(catalog.Runtimes);
+			Assert.Empty(catalog.DeviceTypes);
+			Assert.False(Assert.Single(catalog.Diagnostics).Ready);
+			Assert.Empty(runner.Requests);
+		}
+		finally
+		{
+			commandLineTools.Delete(recursive: true);
+		}
+	}
+
+	[Fact]
+	public async Task GetCatalogAsync_WithFullXcode_LoadsSimulators()
+	{
+		if (!OperatingSystem.IsMacOS())
+			return;
+
+		var root = Directory.CreateTempSubdirectory("mobile-canvas-xcode-");
+		try
+		{
+			var developerDirectory = Path.Combine(root.FullName, "Xcode.app", "Contents", "Developer");
+			Directory.CreateDirectory(Path.Combine(developerDirectory, "Applications", "Simulator.app"));
+			var runner = new RecordingProcessRunner();
+			await using var backend = new IosSimulatorBackend(
+				runner,
+				_ => Task.FromResult(developerDirectory));
+
+			var catalog = await backend.GetCatalogAsync();
+
+			Assert.Equal("ABCD-1234", Assert.Single(catalog.Devices).NativeId);
+			var request = Assert.Single(
+				runner.Requests,
+				request => request.FileName == "xcrun");
+			Assert.Equal(["simctl", "list", "--json"], request.Arguments);
+		}
+		finally
+		{
+			root.Delete(recursive: true);
+		}
+	}
+
+	[Fact]
+	public async Task GetCatalogAsync_WhenSimctlFails_ReturnsUnavailableDiagnostics()
+	{
+		if (!OperatingSystem.IsMacOS())
+			return;
+
+		var root = Directory.CreateTempSubdirectory("mobile-canvas-xcode-failure-");
+		try
+		{
+			var developerDirectory = Path.Combine(root.FullName, "Xcode.app", "Contents", "Developer");
+			Directory.CreateDirectory(Path.Combine(developerDirectory, "Applications", "Simulator.app"));
+			var runner = new RecordingProcessRunner
+			{
+				SimctlResult = new ProcessResult(69, "", "You have not agreed to the Xcode license."),
+			};
+			await using var backend = new IosSimulatorBackend(
+				runner,
+				_ => Task.FromResult(developerDirectory));
+
+			var catalog = await backend.GetCatalogAsync();
+
+			Assert.Empty(catalog.Devices);
+			Assert.False(Assert.Single(catalog.Diagnostics).Available);
+		}
+		finally
+		{
+			root.Delete(recursive: true);
+		}
+	}
+
+	private sealed class RecordingProcessRunner : IProcessRunner
+	{
+		public ProcessResult SimctlResult { get; init; } = new(0, CatalogJson, "");
+		public List<ProcessRequest> Requests { get; } = [];
+
+		public Task<ProcessResult> RunAsync(
+			ProcessRequest request,
+			CancellationToken cancellationToken = default)
+		{
+			Requests.Add(request);
+			return Task.FromResult(
+				request.FileName == "xcrun"
+					? SimctlResult
+					: new ProcessResult(0, "", ""));
+		}
+	}
+}

--- a/tests/web/device-layout.test.mjs
+++ b/tests/web/device-layout.test.mjs
@@ -31,3 +31,8 @@ test("device interaction preserves the normal cursor and click feedback", () => 
   assert.match(rule("#device-screen"), /touch-action:\s*none/);
   assert.match(rule(".input-indicator.active"), /animation:\s*input-ping/);
 });
+
+test("unavailable platforms use an inline picker status with a help link", () => {
+  assert.match(rule(".platform-diagnostic"), /justify-content:\s*space-between/);
+  assert.match(rule(".platform-diagnostic-link"), /color:\s*var\(--accent-fg\)/);
+});

--- a/tests/web/platform-picker.test.mjs
+++ b/tests/web/platform-picker.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canUseDeviceCapability,
+  catalogPlatforms,
+  organizeDiagnostics,
+} from "../../web/canvas-state.js";
+
+test("destructive actions respect backend capabilities", () => {
+  assert.equal(canUseDeviceCapability(null, "delete"), false);
+  assert.equal(canUseDeviceCapability({ capabilities: { delete: false } }, "delete"), false);
+  assert.equal(canUseDeviceCapability({ capabilities: { delete: true } }, "delete"), true);
+  assert.equal(canUseDeviceCapability({ capabilities: {} }, "delete"), true);
+});
+
+test("diagnostic-only platforms remain visible after platforms with devices", () => {
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "android" }],
+    diagnostics: [{ platform: "ios", available: false, ready: false, checks: [] }],
+  }), ["android", "ios"]);
+});
+
+test("unavailable diagnostics keep only safe HTTPS documentation actions", () => {
+  const result = organizeDiagnostics([
+    {
+      platform: "ios",
+      available: false,
+      ready: false,
+      checks: [
+        {
+          name: "iOS",
+          status: "error",
+          message: "iOS requires Xcode.",
+          actions: [
+            {
+              type: "open-url",
+              target: "https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/ios-setup.md",
+              label: "Learn more",
+            },
+            {
+              type: "open-url",
+              target: "http://example.com/unsafe",
+              label: "Unsafe",
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(result.notices, []);
+  assert.deepEqual(result.popover, []);
+  assert.equal(result.unavailable.length, 1);
+  assert.deepEqual(result.unavailable[0].checks[0].actions, [
+    {
+      type: "open-url",
+      target: "https://github.com/Redth/mobile-canvas-ghcp/blob/main/docs/ios-setup.md",
+      label: "Learn more",
+    },
+  ]);
+});
+
+test("non-documentation remediation stays in the existing notice surface", () => {
+  const action = {
+    type: "open-system-settings",
+    target: "screen-recording",
+    label: "Open Screen Recording",
+  };
+  const result = organizeDiagnostics([
+    {
+      platform: "ios",
+      available: true,
+      ready: false,
+      checks: [
+        {
+          name: "ScreenCaptureKit fallback",
+          status: "warning",
+          message: "Grant Screen Recording.",
+          actions: [action],
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(result.unavailable, []);
+  assert.deepEqual(result.popover, []);
+  assert.deepEqual(result.notices[0].actions, [action]);
+});

--- a/vscode/test/canvas-state.test.mjs
+++ b/vscode/test/canvas-state.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   canBootDeviceState,
+  canUseDeviceCapability,
+  catalogPlatforms,
   clearStoredDeviceId,
   deviceStatusPresentation,
   formatDeviceState,
@@ -26,6 +28,12 @@ test("boots stable non-running states but not lifecycle transitions", () => {
   assert.equal(canBootDeviceState("booted"), false);
   assert.equal(canBootDeviceState("booting"), false);
   assert.equal(canBootDeviceState("shutting-down"), false);
+});
+
+test("gates destructive actions on backend capabilities", () => {
+  assert.equal(canUseDeviceCapability(undefined, "delete"), false);
+  assert.equal(canUseDeviceCapability({ capabilities: { delete: false } }, "delete"), false);
+  assert.equal(canUseDeviceCapability({ capabilities: { delete: true } }, "delete"), true);
 });
 
 test("presents readable device state labels", () => {
@@ -221,6 +229,7 @@ test("promotes actionable diagnostics into main notices", () => {
   assert.equal(result.notices[0].name, actionable.name);
   assert.deepEqual(result.notices[0].actions, [actionable.actions[0]]);
   assert.deepEqual(result.popover, [ordinary]);
+  assert.deepEqual(result.unavailable, []);
 });
 
 test("keeps unsupported diagnostic actions in the selector", () => {
@@ -234,6 +243,95 @@ test("keeps unsupported diagnostic actions in the selector", () => {
   assert.deepEqual(organizeDiagnostics([{ checks: [check] }]), {
     notices: [],
     popover: [check],
+    unavailable: [],
   });
-  assert.deepEqual(organizeDiagnostics(null), { notices: [], popover: [] });
+  assert.deepEqual(organizeDiagnostics(null), { notices: [], popover: [], unavailable: [] });
+});
+
+test("orders Android before diagnostic-only unavailable iOS", () => {
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "ios" }, { platform: "android" }],
+    diagnostics: [{ platform: "ios", ready: false, checks: [] }],
+  }), ["android", "ios"]);
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "android" }],
+    diagnostics: [{ platform: "ios", ready: false, checks: [] }],
+  }), ["android", "ios"]);
+});
+
+test("keeps safe unavailable-platform help links in the picker", () => {
+  const result = organizeDiagnostics([
+    {
+      platform: "ios",
+      available: false,
+      ready: false,
+      checks: [
+        {
+          name: "iOS",
+          status: "error",
+          message: "iOS requires Xcode.",
+          actions: [
+            { type: "open-url", target: "https://example.com/ios", label: "Learn more" },
+            { type: "open-url", target: "javascript:alert(1)", label: "Unsafe" },
+          ],
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(result.notices, []);
+  assert.deepEqual(result.popover, []);
+  assert.equal(result.unavailable[0].platform, "ios");
+  assert.deepEqual(result.unavailable[0].checks[0].actions, [
+    { type: "open-url", target: "https://example.com/ios", label: "Learn more" },
+  ]);
+});
+
+test("retains system settings actions when a configured platform is not fully ready", () => {
+  const action = {
+    type: "open-system-settings",
+    target: "accessibility",
+    label: "Open Accessibility",
+  };
+  const result = organizeDiagnostics([
+    {
+      platform: "ios",
+      available: true,
+      ready: false,
+      checks: [
+        {
+          name: "Bundled CoreSimulator HID",
+          status: "error",
+          message: "Input fallback needs Accessibility.",
+          actions: [action],
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(result.unavailable, []);
+  assert.deepEqual(result.popover, []);
+  assert.deepEqual(result.notices[0].actions, [action]);
+});
+
+test("renders unavailable platforms even when they have no documentation action", () => {
+  const result = organizeDiagnostics([
+    {
+      platform: "ios",
+      available: false,
+      ready: false,
+      checks: [
+        {
+          name: "macOS",
+          status: "error",
+          message: "iOS Simulator is only available on macOS.",
+        },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(result.notices, []);
+  assert.deepEqual(result.popover, []);
+  assert.equal(result.unavailable[0].checks[0].message, "iOS Simulator is only available on macOS.");
+  assert.deepEqual(result.unavailable[0].checks[0].actions, []);
 });

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -91,32 +91,85 @@ export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
   };
 }
 
+const PLATFORM_ORDER = ["android", "ios"];
+
+export function catalogPlatforms(catalog) {
+  const seen = new Set();
+  for (const device of catalog?.devices ?? []) addPlatform(seen, device?.platform);
+  for (const runtime of catalog?.runtimes ?? []) addPlatform(seen, runtime?.platform);
+  for (const diagnostic of catalog?.diagnostics ?? []) addPlatform(seen, diagnostic?.platform);
+
+  const known = PLATFORM_ORDER.filter((platform) => seen.has(platform));
+  const extra = [...seen].filter((platform) => !PLATFORM_ORDER.includes(platform)).sort();
+  return [...known, ...extra];
+}
+
 export function organizeDiagnostics(diagnostics) {
-  const failures = (diagnostics ?? [])
-    .flatMap((entry) => entry?.checks ?? [])
-    .filter((check) => check?.status !== "ok")
-    .filter(isActionableDiagnostic)
-    .map((check) => ({
-      ...check,
-      message: formatUserFacingMessage(check.message),
-    }));
   const notices = [];
   const popover = [];
+  const unavailable = [];
 
-  for (const check of failures) {
-    const actions = (check.actions ?? []).filter(
-      (action) =>
-        action?.type === "open-system-settings" &&
-        typeof action.target === "string" &&
-        action.target.length > 0 &&
-        typeof action.label === "string" &&
-        action.label.length > 0,
+  for (const entry of diagnostics ?? []) {
+    const failures = (entry?.checks ?? [])
+      .filter((check) => check?.status !== "ok")
+      .filter(isActionableDiagnostic)
+      .map((check) => ({
+        ...check,
+        message: formatUserFacingMessage(check.message),
+      }));
+
+    const platformChecks = failures.map((check) => ({
+      ...check,
+      actions: (check.actions ?? []).filter(isSafeDocumentationAction),
+    }));
+    const hasUnavailablePlatform = (
+      entry?.available === false
+      && typeof entry.platform === "string"
+      && entry.platform
     );
-    if (actions.length > 0) notices.push({ ...check, actions });
-    else popover.push(check);
+    if (hasUnavailablePlatform) {
+      unavailable.push({
+        platform: entry.platform.toLowerCase(),
+        checks: platformChecks,
+      });
+    }
+
+    for (const check of failures) {
+      if (hasUnavailablePlatform) {
+        continue;
+      }
+      const actions = (check.actions ?? []).filter(isSystemSettingsAction);
+      if (actions.length > 0) notices.push({ ...check, actions });
+      else popover.push(check);
+    }
   }
 
-  return { notices, popover };
+  return { notices, popover, unavailable };
+}
+
+function addPlatform(platforms, value) {
+  const platform = String(value ?? "").trim().toLowerCase();
+  if (platform) platforms.add(platform);
+}
+
+function hasActionLabel(action) {
+  return typeof action?.label === "string" && action.label.length > 0;
+}
+
+function isSystemSettingsAction(action) {
+  return action?.type === "open-system-settings"
+    && typeof action.target === "string"
+    && action.target.length > 0
+    && hasActionLabel(action);
+}
+
+function isSafeDocumentationAction(action) {
+  if (action?.type !== "open-url" || !hasActionLabel(action)) return false;
+  try {
+    return new URL(action.target).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function isActionableDiagnostic(check) {
@@ -141,6 +194,10 @@ export function canBootDeviceState(deviceState) {
   return normalized !== "booted"
     && normalized !== "booting"
     && normalized !== "shutting-down";
+}
+
+export function canUseDeviceCapability(device, capability) {
+  return Boolean(device) && device.capabilities?.[capability] !== false;
 }
 
 const DEVICE_STATE_LABELS = {

--- a/web/device-canvas.css
+++ b/web/device-canvas.css
@@ -454,6 +454,27 @@ summary:focus-visible,
   background: var(--accent-muted);
 }
 
+.platform-diagnostic {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  color: var(--attention-fg);
+  font-size: 12px;
+}
+
+.platform-diagnostic-link {
+  flex: none;
+  color: var(--accent-fg);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.platform-diagnostic-link:hover {
+  text-decoration: underline;
+}
+
 .device-glyph {
   display: grid;
   place-items: center;

--- a/web/device-canvas.js
+++ b/web/device-canvas.js
@@ -6,6 +6,8 @@ import {
 } from "./create-device-options.js";
 import {
   canBootDeviceState,
+  canUseDeviceCapability,
+  catalogPlatforms,
   clearStoredDeviceId,
   createFramePrimer,
   createLatestCatalogLoader,
@@ -343,8 +345,6 @@ const PLATFORMS = {
   },
 };
 
-const PLATFORM_ORDER = ["ios", "android"];
-
 function platformInfo(platform) {
   return PLATFORMS[platform] || { label: "Devices", noun: "device", icon: "#icon-device", provider: "" };
 }
@@ -353,25 +353,19 @@ function capitalize(value) {
   return value ? value[0].toUpperCase() + value.slice(1) : value;
 }
 
-/** Platforms that actually reported something, in a stable order, so headings never flicker. */
 function availablePlatforms() {
-  const seen = new Set();
-  for (const device of state.catalog?.devices || []) seen.add(device.platform);
-  for (const runtime of state.catalog?.runtimes || []) seen.add(runtime.platform);
-  const known = PLATFORM_ORDER.filter((platform) => seen.has(platform));
-  const extra = [...seen].filter((platform) => platform && !PLATFORM_ORDER.includes(platform)).sort();
-  return [...known, ...extra];
+  return catalogPlatforms(state.catalog);
 }
 
 function renderDeviceList() {
   const devices = state.catalog?.devices || [];
+  const { unavailable } = organizeDiagnostics(state.catalog?.diagnostics);
   elements.list.replaceChildren();
 
   // Every group is headed, including on a single-platform machine: the heading now carries the
   // count, so dropping it would leave the menu with no total at all.
   for (const platform of availablePlatforms()) {
     const group = devices.filter((device) => device.platform === platform);
-    if (group.length === 0) continue;
 
     const heading = document.createElement("div");
     heading.className = "device-group";
@@ -382,7 +376,33 @@ function renderDeviceList() {
     elements.list.append(heading);
 
     for (const device of group) elements.list.append(createDeviceCard(device));
+    for (const diagnostic of unavailable.filter((entry) => entry.platform === platform)) {
+      for (const check of diagnostic.checks) {
+        elements.list.append(createPlatformDiagnostic(check));
+      }
+    }
   }
+}
+
+function createPlatformDiagnostic(check) {
+  const item = document.createElement("div");
+  item.className = "platform-diagnostic";
+  item.setAttribute("role", "status");
+
+  const message = document.createElement("span");
+  message.textContent = check.message;
+  item.append(message);
+
+  for (const action of check.actions ?? []) {
+    const link = document.createElement("a");
+    link.className = "platform-diagnostic-link";
+    link.href = action.target;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = action.label;
+    item.append(link);
+  }
+  return item;
 }
 
 function createDeviceCard(device) {
@@ -662,8 +682,8 @@ function updateControlAvailability() {
 
   const erase = document.querySelector("#erase-button");
   const remove = document.querySelector("#delete-button");
-  erase.disabled = !state.selected;
-  remove.disabled = !state.selected;
+  erase.disabled = !canUseDeviceCapability(state.selected, "erase");
+  remove.disabled = !canUseDeviceCapability(state.selected, "delete");
 
   const identifier = identifierLabels(state.selected?.platform);
   elements.udidLabel.textContent = identifier.label;


### PR DESCRIPTION
Missing Xcode currently prevents the combined device catalog from returning otherwise usable Android emulators. This change models platform prerequisites independently so one unavailable toolchain does not block the other host workflow.

- Return concise, linked unavailable states for missing or unusable iOS and Android toolchains.
- Order Android before unavailable iOS in the shared device picker used by both the GitHub App canvas and VS Code.
- Require the Android SDK, `adb`, and `emulator` for normal use, while treating Java and `avdmanager` as AVD creation/deletion dependencies only.
- Probe AVD-management support before advertising or running destructive operations, including safe Windows batch invocation.
- Add versioned Android and iOS setup guides.

Validated with the full .NET test suite, VS Code unit/integration tests, and both shipping package verification paths.

Fixes: #88