### PR TITLE
Fix managed backend lifecycle handling

### DIFF
--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -3,82 +3,82 @@
     "darwin-arm64": {
       "rid": "osx-arm64",
       "executable": "mobile-canvas",
-      "id": "f7a163ef331cf205eedaaf65d98436aa3f81551942a70135c1e4868ab4daeb7b",
+      "id": "2600f796da7072f46ae5b46ad49f6dba1b8896c82df38f4558f066d45e28e90a",
       "files": {
         "mobile-canvas": {
-          "sha256": "f7a163ef331cf205eedaaf65d98436aa3f81551942a70135c1e4868ab4daeb7b",
-          "size": 32360080,
-          "asset": "mobile-canvas-v0.1.18-osx-arm64.gz"
+          "sha256": "2600f796da7072f46ae5b46ad49f6dba1b8896c82df38f4558f066d45e28e90a",
+          "size": 32376720,
+          "asset": "mobile-canvas-v0.1.18-rc.1-osx-arm64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.18-osx-arm64.gz"
+          "asset": "mobile-screencap-v0.1.18-rc.1-osx-arm64.gz"
         }
       }
     },
     "darwin-x64": {
       "rid": "osx-x64",
       "executable": "mobile-canvas",
-      "id": "bcef0712624bfd54d1d12df4eecce45e5d0d96a4c745095df779d3344219b570",
+      "id": "0848812fadc3dba7c77e2b05d36920a0896ca4c8ea72d28e5cf3b26b18a1293d",
       "files": {
         "mobile-canvas": {
-          "sha256": "bcef0712624bfd54d1d12df4eecce45e5d0d96a4c745095df779d3344219b570",
-          "size": 34102792,
-          "asset": "mobile-canvas-v0.1.18-osx-x64.gz"
+          "sha256": "0848812fadc3dba7c77e2b05d36920a0896ca4c8ea72d28e5cf3b26b18a1293d",
+          "size": 34131592,
+          "asset": "mobile-canvas-v0.1.18-rc.1-osx-x64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.18-osx-x64.gz"
+          "asset": "mobile-screencap-v0.1.18-rc.1-osx-x64.gz"
         }
       }
     },
     "linux-arm64": {
       "rid": "linux-arm64",
       "executable": "mobile-canvas",
-      "id": "ab580d94e0e06c60054d84f8da05d91b069159fd8f9187bbe4e991ef11e5f5df",
+      "id": "0e95d5ec10ec484f3f232f3f7a6d2172c7af066ebfcb6b005480a533fe08260e",
       "files": {
         "mobile-canvas": {
-          "sha256": "ab580d94e0e06c60054d84f8da05d91b069159fd8f9187bbe4e991ef11e5f5df",
-          "size": 34484632,
-          "asset": "mobile-canvas-v0.1.18-linux-arm64.gz"
+          "sha256": "0e95d5ec10ec484f3f232f3f7a6d2172c7af066ebfcb6b005480a533fe08260e",
+          "size": 34485104,
+          "asset": "mobile-canvas-v0.1.18-rc.1-linux-arm64.gz"
         }
       }
     },
     "linux-x64": {
       "rid": "linux-x64",
       "executable": "mobile-canvas",
-      "id": "ef74c4ae266cfa51fe854ab36aaf77eb527afd4422f3c7b50489672c1c511814",
+      "id": "8fa0132790887a4f0ed5b22b691b68b96f830c3954d8e694b82b306e5e7aa51f",
       "files": {
         "mobile-canvas": {
-          "sha256": "ef74c4ae266cfa51fe854ab36aaf77eb527afd4422f3c7b50489672c1c511814",
-          "size": 33771696,
-          "asset": "mobile-canvas-v0.1.18-linux-x64.gz"
+          "sha256": "8fa0132790887a4f0ed5b22b691b68b96f830c3954d8e694b82b306e5e7aa51f",
+          "size": 33792656,
+          "asset": "mobile-canvas-v0.1.18-rc.1-linux-x64.gz"
         }
       }
     },
     "win32-arm64": {
       "rid": "win-arm64",
       "executable": "mobile-canvas.exe",
-      "id": "fcb26008de013c3f58fd92e6483c2efb8ba61cca55b5b8df44ade90c7398d42e",
+      "id": "31daff6d2262337680596a6003ebdf8247eabee6ef6ad1012db1b374071757c1",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "fcb26008de013c3f58fd92e6483c2efb8ba61cca55b5b8df44ade90c7398d42e",
-          "size": 38107136,
-          "asset": "mobile-canvas-v0.1.18-win-arm64.gz"
+          "sha256": "31daff6d2262337680596a6003ebdf8247eabee6ef6ad1012db1b374071757c1",
+          "size": 38136320,
+          "asset": "mobile-canvas-v0.1.18-rc.1-win-arm64.gz"
         }
       }
     },
     "win32-x64": {
       "rid": "win-x64",
       "executable": "mobile-canvas.exe",
-      "id": "20417ec46b1d6a572aa15ea62733208cd351b14345d29e66666819cbe9552d77",
+      "id": "8e16a57d9d443679bb030cce3b55b87c50a4058a49a2c86716df31dc1d4e0a87",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "20417ec46b1d6a572aa15ea62733208cd351b14345d29e66666819cbe9552d77",
-          "size": 37409792,
-          "asset": "mobile-canvas-v0.1.18-win-x64.gz"
+          "sha256": "8e16a57d9d443679bb030cce3b55b87c50a4058a49a2c86716df31dc1d4e0a87",
+          "size": 37436928,
+          "asset": "mobile-canvas-v0.1.18-rc.1-win-x64.gz"
         }
       }
     }
@@ -86,7 +86,7 @@
   "version": "0.1.18",
   "distribution": {
     "repository": "Redth/mobile-canvas-ghcp",
-    "tag": "v0.1.18"
+    "tag": "v0.1.18-rc.1"
   },
-  "sourceHash": "43eae28c77d01be5646b27f82efa6facb78ff7b0a329f521d1f0dc70dc38321e"
+  "sourceHash": "340d390acd0d70dfc1db1106a7f99208a4ff0617efc7529c3315ef37363afb19"
 }

--- a/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
+++ b/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
@@ -57,6 +57,9 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 	private static readonly TimeSpan DisplayStateProbeTimeout = TimeSpan.FromSeconds(2);
 	private static readonly TimeSpan RotationSettleTimeout = TimeSpan.FromSeconds(5);
 	private static readonly TimeSpan InputCommandTimeout = TimeSpan.FromSeconds(8);
+	private static readonly TimeSpan ShutdownCommandTimeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan ShutdownExitTimeout = TimeSpan.FromSeconds(45);
+	private static readonly TimeSpan ShutdownPollInterval = TimeSpan.FromMilliseconds(400);
 
 	private readonly Lock _geometryLock = new();
 	private readonly Dictionary<string, DisplayGeometry> _geometryCache = new(StringComparer.OrdinalIgnoreCase);
@@ -695,13 +698,31 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 			try
 			{
 				var connection = await _connections.GetAsync(instance, cancellationToken).ConfigureAwait(false);
-				await connection.Client
-					.setVmStateAsync(
-						new VmRunState { State = VmRunState.Types.RunState.Shutdown },
-						connection.Metadata,
-						cancellationToken: cancellationToken)
-					.ConfigureAwait(false);
-				stopped = true;
+				stopped = await TryRunShutdownCommandAsync(
+					async token =>
+					{
+						await connection.Client
+							.setVmStateAsync(
+								new VmRunState { State = VmRunState.Types.RunState.Shutdown },
+								connection.Metadata,
+								cancellationToken: token)
+							.ConfigureAwait(false);
+					},
+					ShutdownCommandTimeout,
+					cancellationToken).ConfigureAwait(false);
+				if (!stopped)
+				{
+					_logger.LogDebug(
+						"gRPC shutdown timed out for {Avd}; falling back to adb.",
+						avdId);
+				}
+			}
+			catch (RpcException exception) when (cancellationToken.IsCancellationRequested)
+			{
+				throw new OperationCanceledException(
+					"Android emulator shutdown was canceled.",
+					exception,
+					cancellationToken);
 			}
 			catch (RpcException exception)
 			{
@@ -710,32 +731,113 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		}
 
 		if (!stopped && instance.Serial is { } serial)
-			await RunAdbAsync(serial, ["emu", "kill"], cancellationToken).ConfigureAwait(false);
+		{
+			var fallbackCompleted = await TryRunShutdownCommandAsync(
+				async token =>
+				{
+					await RunAdbAsync(serial, ["emu", "kill"], token).ConfigureAwait(false);
+				},
+				ShutdownCommandTimeout,
+				cancellationToken).ConfigureAwait(false);
+			if (!fallbackCompleted)
+				_logger.LogDebug("adb shutdown timed out for {Avd}; waiting for process exit.", avdId);
+		}
 
 		await _connections.RemoveAsync(avdId).ConfigureAwait(false);
-		await WaitForExitAsync(avdId, cancellationToken).ConfigureAwait(false);
+		await WaitForExitAsync(instance, cancellationToken).ConfigureAwait(false);
 		InvalidateCache(avdId);
 
 		return await GetDeviceAsync(deviceId, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <summary>
-	/// Waits for the emulator's discovery file to disappear. Relaunching before it does produces a
-	/// second instance that silently starts without gRPC, because the ports are still held.
+	/// Waits for both the emulator's discovery file and original process to disappear. Relaunching
+	/// before either does can produce a second instance without gRPC because the ports are still held.
 	/// </summary>
-	private async Task WaitForExitAsync(string avdId, CancellationToken cancellationToken)
+	private async Task WaitForExitAsync(EmulatorInstance instance, CancellationToken cancellationToken)
 	{
-		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		timeout.CancelAfter(TimeSpan.FromSeconds(45));
+		await WaitForTerminalStateAsync(
+			instance.AvdId,
+			() => IsShutdownTerminal(
+				FindRunning(instance.AvdId) is null,
+				HasProcessExited(instance.ProcessId)),
+			ShutdownExitTimeout,
+			ShutdownPollInterval,
+			cancellationToken).ConfigureAwait(false);
+	}
+
+	internal static bool IsShutdownTerminal(bool discoveryEntryRemoved, bool processExited) =>
+		discoveryEntryRemoved && processExited;
+
+	private static bool HasProcessExited(int processId)
+	{
+		if (processId <= 0)
+			return false;
 
 		try
 		{
-			while (FindRunning(avdId) is not null)
-				await Task.Delay(TimeSpan.FromMilliseconds(400), timeout.Token).ConfigureAwait(false);
+			using var process = Process.GetProcessById(processId);
+			return process.HasExited;
 		}
-		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		catch (ArgumentException)
 		{
-			_logger.LogWarning("Emulator {Avd} did not release its ports within 45 seconds.", avdId);
+			return true;
+		}
+		catch (InvalidOperationException)
+		{
+			return true;
+		}
+	}
+
+	internal static async Task<bool> TryRunShutdownCommandAsync(
+		Func<CancellationToken, Task> command,
+		TimeSpan timeout,
+		CancellationToken cancellationToken)
+	{
+		using var commandTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		commandTimeout.CancelAfter(timeout);
+
+		try
+		{
+			await command(commandTimeout.Token).ConfigureAwait(false);
+			return true;
+		}
+		catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+		{
+			throw new OperationCanceledException(
+				"Android emulator shutdown was canceled.",
+				exception,
+				cancellationToken);
+		}
+		catch (OperationCanceledException) when (
+			!cancellationToken.IsCancellationRequested &&
+			commandTimeout.IsCancellationRequested)
+		{
+			return false;
+		}
+	}
+
+	internal static async Task WaitForTerminalStateAsync(
+		string avdId,
+		Func<bool> hasExited,
+		TimeSpan timeout,
+		TimeSpan pollInterval,
+		CancellationToken cancellationToken)
+	{
+		using var exitTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		exitTimeout.CancelAfter(timeout);
+
+		try
+		{
+			while (!hasExited())
+				await Task.Delay(pollInterval, exitTimeout.Token).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException) when (
+			!cancellationToken.IsCancellationRequested &&
+			exitTimeout.IsCancellationRequested)
+		{
+			throw new TimeoutException(
+				$"Emulator '{avdId}' did not shut down within {timeout.TotalSeconds:0} seconds.");
 		}
 	}
 

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -27,7 +27,8 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	// shutdown, and the latter surfaces as a companion failure anyway.
 	private readonly ConcurrentDictionary<string, (DeviceTarget Device, long Stamp)> _bootedCache = new();
 	private readonly ConcurrentDictionary<string, bool> _revalidating = new();
-	private readonly ConcurrentDictionary<string, string> _orientations = new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, CachedOrientation> _orientations =
+		new(StringComparer.OrdinalIgnoreCase);
 	private readonly ConcurrentDictionary<string, ActiveHidRoute> _activeTouches =
 		new(StringComparer.OrdinalIgnoreCase);
 	private readonly ConcurrentDictionary<string, SemaphoreSlim> _inputGates =
@@ -39,6 +40,8 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	private static readonly TimeSpan FramebufferStartupTimeout = TimeSpan.FromSeconds(15);
 	private static readonly TimeSpan FramebufferRetryTimeout = TimeSpan.FromSeconds(8);
 	private static readonly TimeSpan FramebufferRetryDelay = TimeSpan.FromMilliseconds(250);
+	private static readonly TimeSpan OrientationCacheLifetime = TimeSpan.FromSeconds(5);
+	private sealed record CachedOrientation(string Orientation, long Stamp);
 
 	public IosSimulatorBackend(IProcessRunner processRunner)
 		: this(
@@ -134,9 +137,20 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		var result = await RunAsync(arguments, cancellationToken).ConfigureAwait(false);
 		EnsureSuccess("xcrun", ["simctl", .. arguments], result);
 		var display = SimctlDisplayParser.Parse(result.StandardOutput);
-		display = SimulatorOrientation.Apply(
-			display,
-			_orientations.GetValueOrDefault(device.NativeId, "portrait"));
+		display = SimulatorOrientation.Apply(display, display.Orientation);
+		if (_orientations.TryGetValue(device.NativeId, out var cached))
+		{
+			var reconciled = ReconcileOrientation(
+				display,
+				cached.Orientation,
+				Stopwatch.GetElapsedTime(cached.Stamp));
+			display = reconciled.Display;
+			if (!reconciled.RetainCache)
+			{
+				((ICollection<KeyValuePair<string, CachedOrientation>>)_orientations)
+					.Remove(new KeyValuePair<string, CachedOrientation>(device.NativeId, cached));
+			}
+		}
 
 		var cornerRadius = await _profiles.TryGetCornerRadiusAsync(
 			device.DeviceTypeId,
@@ -478,7 +492,24 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			new ProcessRequest(helperPath, arguments),
 			cancellationToken).ConfigureAwait(false);
 		EnsureSuccess(helperPath, arguments, result);
-		_orientations[device.NativeId] = normalizedOrientation;
+		_orientations[device.NativeId] = new CachedOrientation(
+			normalizedOrientation,
+			Stopwatch.GetTimestamp());
+	}
+
+	internal static (DisplayGeometry Display, bool RetainCache) ReconcileOrientation(
+		DisplayGeometry authoritativeDisplay,
+		string? cachedOrientation,
+		TimeSpan cacheAge)
+	{
+		if (string.IsNullOrWhiteSpace(cachedOrientation) ||
+			cachedOrientation.Equals(authoritativeDisplay.Orientation, StringComparison.Ordinal) ||
+			cacheAge >= OrientationCacheLifetime)
+		{
+			return (authoritativeDisplay, false);
+		}
+
+		return (SimulatorOrientation.Apply(authoritativeDisplay, cachedOrientation), true);
 	}
 
 	public async Task<byte[]> ScreenshotAsync(string deviceId, CancellationToken cancellationToken = default)

--- a/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidEmulatorBackendTests.cs
@@ -430,6 +430,67 @@ public sealed class AndroidEmulatorBackendTests
 			GetAvdManagerArguments(runner.Calls[^1].Request));
 	}
 
+	[Fact]
+	public async Task ShutdownCommand_TimeoutAllowsFallback()
+	{
+		var stopped = await AndroidEmulatorBackend.TryRunShutdownCommandAsync(
+			async token => await Task.Delay(Timeout.InfiniteTimeSpan, token),
+			TimeSpan.FromMilliseconds(20),
+			CancellationToken.None);
+
+		Assert.False(stopped);
+	}
+
+	[Fact]
+	public async Task ShutdownCommand_PreservesCallerCancellation()
+	{
+		using var cancellation = new CancellationTokenSource();
+		cancellation.Cancel();
+
+		var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			AndroidEmulatorBackend.TryRunShutdownCommandAsync(
+				token => Task.Delay(Timeout.InfiniteTimeSpan, token),
+				TimeSpan.FromSeconds(1),
+				cancellation.Token));
+
+		Assert.Equal(cancellation.Token, exception.CancellationToken);
+	}
+
+	[Fact]
+	public async Task ShutdownExitWait_CompletesOnlyAfterTerminalState()
+	{
+		var probes = 0;
+
+		await AndroidEmulatorBackend.WaitForTerminalStateAsync(
+			"test_avd",
+			() =>
+			{
+				probes++;
+				return AndroidEmulatorBackend.IsShutdownTerminal(
+					discoveryEntryRemoved: probes >= 2,
+					processExited: probes >= 3);
+			},
+			TimeSpan.FromSeconds(1),
+			TimeSpan.FromMilliseconds(1),
+			CancellationToken.None);
+
+		Assert.Equal(3, probes);
+	}
+
+	[Fact]
+	public async Task ShutdownExitWait_ThrowsWhileEmulatorRemainsAlive()
+	{
+		var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+			AndroidEmulatorBackend.WaitForTerminalStateAsync(
+				"test_avd",
+				() => false,
+				TimeSpan.FromMilliseconds(20),
+				TimeSpan.FromMilliseconds(1),
+				CancellationToken.None));
+
+		Assert.Contains("did not shut down", exception.Message, StringComparison.Ordinal);
+	}
+
 	private static IReadOnlyList<string> GetAvdManagerArguments(ProcessRequest request)
 	{
 		if (request.Environment is null)

--- a/tests/MobileCanvas.Tests/IosSimulatorBackendTests.cs
+++ b/tests/MobileCanvas.Tests/IosSimulatorBackendTests.cs
@@ -29,6 +29,29 @@ public sealed class IosSimulatorBackendTests
 		  }
 		}
 		""";
+	private const string BootedCatalogJson = """
+		{
+		  "runtimes": [{
+		    "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+		    "name": "iOS 18.6",
+		    "version": "18.6",
+		    "isAvailable": true
+		  }],
+		  "devicetypes": [{
+		    "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+		    "name": "iPhone 16 Pro"
+		  }],
+		  "devices": {
+		    "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [{
+		      "name": "Test iPhone",
+		      "udid": "ABCD-1234",
+		      "state": "Booted",
+		      "isAvailable": true,
+		      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro"
+		    }]
+		  }
+		}
+		""";
 
 	[Fact]
 	public void MissingXcodeDiagnostic_IsConciseAndLinksToTheSetupGuide()
@@ -148,9 +171,101 @@ public sealed class IosSimulatorBackendTests
 		}
 	}
 
+	[Fact]
+	public async Task GetDisplayAsync_UsesOrientationObservedBeforeThisProcessStarted()
+	{
+		if (!OperatingSystem.IsMacOS())
+			return;
+
+		var root = Directory.CreateTempSubdirectory("mobile-canvas-xcode-orientation-");
+		try
+		{
+			var developerDirectory = Path.Combine(root.FullName, "Xcode.app", "Contents", "Developer");
+			Directory.CreateDirectory(Path.Combine(developerDirectory, "Applications", "Simulator.app"));
+			var runner = new RecordingProcessRunner
+			{
+				Handler = request => request.Arguments switch
+				{
+					["simctl", "list", "--json"] => new ProcessResult(0, BootedCatalogJson, ""),
+					["simctl", "io", "ABCD-1234", "enumerate"] => new ProcessResult(0, """
+						Connected Screens:
+						    (1) LCD:
+						        Pixel Size: {1125, 2436}
+						        Preferred UI Scale: 3
+						        UI Orientation: Landscape Right
+						""", ""),
+					["simctl", "list", "devicetypes", "--json"] => new ProcessResult(
+						0,
+						"""{"devicetypes":[]}""",
+						""),
+					_ => throw new InvalidOperationException(
+						$"Unexpected process request: {request.FileName} {string.Join(' ', request.Arguments)}"),
+				},
+			};
+			await using var backend = new IosSimulatorBackend(
+				runner,
+				_ => Task.FromResult(developerDirectory));
+
+			var display = await backend.GetDisplayAsync("ios:core-simulator:ABCD-1234");
+
+			Assert.Equal("landscape-right", display.Orientation);
+			Assert.Equal(2436, display.PixelWidth);
+			Assert.Equal(1125, display.PixelHeight);
+		}
+		finally
+		{
+			root.Delete(recursive: true);
+		}
+	}
+
+	[Fact]
+	public void OrientationCache_ExpiresInFavorOfAuthoritativeState()
+	{
+		var authoritative = new DisplayGeometry
+		{
+			PixelWidth = 2436,
+			PixelHeight = 1125,
+			PointWidth = 812,
+			PointHeight = 375,
+			Scale = 3,
+			Orientation = "landscape-right",
+		};
+
+		var reconciled = IosSimulatorBackend.ReconcileOrientation(
+			authoritative,
+			"portrait",
+			TimeSpan.FromMinutes(1));
+
+		Assert.Same(authoritative, reconciled.Display);
+		Assert.False(reconciled.RetainCache);
+	}
+
+	[Fact]
+	public void OrientationCache_IsDiscardedWhenSimctlHasReconciled()
+	{
+		var authoritative = new DisplayGeometry
+		{
+			PixelWidth = 2436,
+			PixelHeight = 1125,
+			PointWidth = 812,
+			PointHeight = 375,
+			Scale = 3,
+			Orientation = "landscape-left",
+		};
+
+		var reconciled = IosSimulatorBackend.ReconcileOrientation(
+			authoritative,
+			"landscape-left",
+			TimeSpan.Zero);
+
+		Assert.Same(authoritative, reconciled.Display);
+		Assert.False(reconciled.RetainCache);
+	}
+
 	private sealed class RecordingProcessRunner : IProcessRunner
 	{
 		public ProcessResult SimctlResult { get; init; } = new(0, CatalogJson, "");
+		public Func<ProcessRequest, ProcessResult>? Handler { get; init; }
 		public List<ProcessRequest> Requests { get; } = [];
 
 		public Task<ProcessResult> RunAsync(
@@ -158,6 +273,8 @@ public sealed class IosSimulatorBackendTests
 			CancellationToken cancellationToken = default)
 		{
 			Requests.Add(request);
+			if (Handler is not null)
+				return Task.FromResult(Handler(request));
 			return Task.FromResult(
 				request.FileName == "xcrun"
 					? SimctlResult


### PR DESCRIPTION
## Summary

- bound Android emulator gRPC and adb shutdown commands before exit polling
- preserve caller cancellation and require both discovery removal and original process exit before reporting shutdown success
- use authoritative simctl orientation as the iOS display baseline, with a short-lived concurrency-safe cache only for local rotation propagation
- add focused shutdown timeout/cancellation/fallback/terminal-state and external iOS orientation coverage
- refresh the runtime manifest from the canonical `v0.1.18-rc.1` artifacts built from this managed source

## Validation

- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --filter 'FullyQualifiedName~AndroidEmulatorBackendTests|FullyQualifiedName~IosSimulatorBackendTests|FullyQualifiedName~SimulatorOrientationTests|FullyQualifiedName~SimctlParserTests' --no-restore --logger 'console;verbosity=minimal'` — 48 passed\n- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --no-restore --logger 'console;verbosity=minimal'` — 393 passed\n- `node scripts/source-hash.mjs --check`\n- `node scripts/verify-bundle.mjs`\n- `node scripts/smoke-runtime.mjs` — downloaded runtime started host 0.1.18 and listed devices\n- blocker-only code review — no findings\n\n## Ailoha export\n\nNo native source or runtime binaries are committed. PR #85 exports every tracked source file through `git ls-files`; after composing/merging both PRs, the managed files and updated runtime manifest are included automatically and the aggregate snapshot hash changes.