### PR TITLE
Release Mobile Canvas 0.1.18

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "mobile-canvas",
       "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "author": {
         "name": "Jonathan Dick",
         "url": "https://github.com/Redth"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-canvas",
   "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "author": {
     "name": "Jonathan Dick",
     "url": "https://github.com/Redth"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "mobile-canvas",
       "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "author": {
         "name": "Jonathan Dick",
         "url": "https://github.com/Redth"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-canvas",
   "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "author": {
     "name": "Jonathan Dick",
     "url": "https://github.com/Redth"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.1.17</VersionPrefix>
+    <VersionPrefix>0.1.18</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/native/mobile-screencap/test.sh
+++ b/native/mobile-screencap/test.sh
@@ -148,7 +148,8 @@ PY
 
 	# Existing commands must keep working: a rename or a new dispatch arm cannot regress Android's
 	# use of the same executable.
-	"$HELPER" --help 2>&1 | grep -q "encode" || {
+	"$HELPER" --help > "$BUILD_DIR/help.txt" 2>&1
+	grep -q "encode" "$BUILD_DIR/help.txt" || {
 		echo "the helper no longer advertises 'encode'" >&2
 		exit 1
 	}
@@ -157,7 +158,7 @@ PY
 	# The accessibility reader must fail the same startup-frame way as `hid` for a device that does
 	# not exist -- no protocolVersion field (it never emitted one), but the same
 	# type/code/message/non-zero-exit shape a managed caller already knows how to fall back from.
-	"$HELPER" --help 2>&1 | grep -q "accessibility" || {
+	grep -q "accessibility" "$BUILD_DIR/help.txt" || {
 		echo "the helper no longer advertises 'accessibility'" >&2
 		exit 1
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-canvas",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Run and control local iOS Simulators and Android emulators in a live Copilot canvas, with agent-ready device automation.",
   "main": "extension.mjs",
   "type": "module",

--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -3,90 +3,90 @@
     "darwin-arm64": {
       "rid": "osx-arm64",
       "executable": "mobile-canvas",
-      "id": "07d3c0bd2179ed7226b7677ad13f70607fe2d77812c1e70419d9839235206700",
+      "id": "e1c48197bcffa3b5fd7ba6e47b02307b13ae14c8b1afcbdd1a2ed9928497d58c",
       "files": {
         "mobile-canvas": {
-          "sha256": "07d3c0bd2179ed7226b7677ad13f70607fe2d77812c1e70419d9839235206700",
-          "size": 32293808,
-          "asset": "mobile-canvas-v0.1.17-rc.4-osx-arm64.gz"
+          "sha256": "e1c48197bcffa3b5fd7ba6e47b02307b13ae14c8b1afcbdd1a2ed9928497d58c",
+          "size": 32360080,
+          "asset": "mobile-canvas-v0.1.18-osx-arm64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.17-rc.4-osx-arm64.gz"
+          "asset": "mobile-screencap-v0.1.18-osx-arm64.gz"
         }
       }
     },
     "darwin-x64": {
       "rid": "osx-x64",
       "executable": "mobile-canvas",
-      "id": "c03fdad4f692209a1adbbce8a4b6a9414b566c6d9c7b4fe56b3aeed3a97fdbc7",
+      "id": "99d6c943a9bc8d7c79fbc868a5a7ecd20b88ea94f489c92b5034b98721b21ad8",
       "files": {
         "mobile-canvas": {
-          "sha256": "c03fdad4f692209a1adbbce8a4b6a9414b566c6d9c7b4fe56b3aeed3a97fdbc7",
-          "size": 34041144,
-          "asset": "mobile-canvas-v0.1.17-rc.4-osx-x64.gz"
+          "sha256": "99d6c943a9bc8d7c79fbc868a5a7ecd20b88ea94f489c92b5034b98721b21ad8",
+          "size": 34102792,
+          "asset": "mobile-canvas-v0.1.18-osx-x64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.17-rc.4-osx-x64.gz"
+          "asset": "mobile-screencap-v0.1.18-osx-x64.gz"
         }
       }
     },
     "linux-arm64": {
       "rid": "linux-arm64",
       "executable": "mobile-canvas",
-      "id": "82a033e519d287e76fa91b5eb62a08a4cb81658e9daa2da759e0d0492f3ec428",
+      "id": "fefd5c157956a339ba6ccf0047f3949e5da143328bc5f7a490ad5394820c067e",
       "files": {
         "mobile-canvas": {
-          "sha256": "82a033e519d287e76fa91b5eb62a08a4cb81658e9daa2da759e0d0492f3ec428",
-          "size": 34417856,
-          "asset": "mobile-canvas-v0.1.17-rc.4-linux-arm64.gz"
+          "sha256": "fefd5c157956a339ba6ccf0047f3949e5da143328bc5f7a490ad5394820c067e",
+          "size": 34484632,
+          "asset": "mobile-canvas-v0.1.18-linux-arm64.gz"
         }
       }
     },
     "linux-x64": {
       "rid": "linux-x64",
       "executable": "mobile-canvas",
-      "id": "5e3dd43058df1bf082e60418556a972964d3f086c36ed02119868ce8d4660ca7",
+      "id": "076954574f848a5209556e61914c47bdf2f1624c479ac30a135de9544a65bded",
       "files": {
         "mobile-canvas": {
-          "sha256": "5e3dd43058df1bf082e60418556a972964d3f086c36ed02119868ce8d4660ca7",
-          "size": 33709008,
-          "asset": "mobile-canvas-v0.1.17-rc.4-linux-x64.gz"
+          "sha256": "076954574f848a5209556e61914c47bdf2f1624c479ac30a135de9544a65bded",
+          "size": 33771696,
+          "asset": "mobile-canvas-v0.1.18-linux-x64.gz"
         }
       }
     },
     "win32-arm64": {
       "rid": "win-arm64",
       "executable": "mobile-canvas.exe",
-      "id": "f8db6c1de6c6a8bc3c311182375ed7996c59e8244d53adedf5382a229f31feaa",
+      "id": "e21b195fae6342cd6b04dc864cd72581b3ce1a9a2c667c330432b9585ece0485",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "f8db6c1de6c6a8bc3c311182375ed7996c59e8244d53adedf5382a229f31feaa",
-          "size": 38033920,
-          "asset": "mobile-canvas-v0.1.17-rc.4-win-arm64.gz"
+          "sha256": "e21b195fae6342cd6b04dc864cd72581b3ce1a9a2c667c330432b9585ece0485",
+          "size": 38107136,
+          "asset": "mobile-canvas-v0.1.18-win-arm64.gz"
         }
       }
     },
     "win32-x64": {
       "rid": "win-x64",
       "executable": "mobile-canvas.exe",
-      "id": "225cbd6a670d2716a07a5cecd0d16a35f756502589b3e24282e3fc4d0f675086",
+      "id": "6c9f10d9dfee42450df1862ed26580989388e9bb57f09ad3ad72db935abc394f",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "225cbd6a670d2716a07a5cecd0d16a35f756502589b3e24282e3fc4d0f675086",
-          "size": 37337088,
-          "asset": "mobile-canvas-v0.1.17-rc.4-win-x64.gz"
+          "sha256": "6c9f10d9dfee42450df1862ed26580989388e9bb57f09ad3ad72db935abc394f",
+          "size": 37409792,
+          "asset": "mobile-canvas-v0.1.18-win-x64.gz"
         }
       }
     }
   },
-  "version": "0.1.17",
+  "version": "0.1.18",
   "distribution": {
     "repository": "Redth/mobile-canvas-ghcp",
-    "tag": "v0.1.17-rc.4"
+    "tag": "v0.1.18"
   },
-  "sourceHash": "30f2323c84363778ee5a84b370339b8e3d2bbc7cb43ed433879fabcebb2e68c5"
+  "sourceHash": "43eae28c77d01be5646b27f82efa6facb78ff7b0a329f521d1f0dc70dc38321e"
 }

--- a/src/MobileCanvas.iOS/IosScreenCaptureVideoSession.cs
+++ b/src/MobileCanvas.iOS/IosScreenCaptureVideoSession.cs
@@ -36,7 +36,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 		StreamOptions options,
 		DisplayGeometry display,
 		Action release,
-		CancellationToken cancellationToken) =>
+		CancellationToken cancellationToken,
+		TimeSpan? startupTimeout = null) =>
 		StartProcessAsync(
 			CreateFramebufferStartInfo(helperPath, nativeId, options, display),
 			options,
@@ -44,7 +45,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 			"framebuffer",
 			sourceDetail: null,
 			release,
-			cancellationToken);
+			cancellationToken,
+			startupTimeout ?? TimeSpan.FromSeconds(15));
 
 	public static async Task<IosScreenCaptureVideoSession> StartAsync(
 		string helperPath,
@@ -61,7 +63,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 			"screencapturekit",
 			sourceDetail,
 			release,
-			cancellationToken).ConfigureAwait(false);
+			cancellationToken,
+			TimeSpan.FromSeconds(15)).ConfigureAwait(false);
 
 	internal static ProcessStartInfo CreateFramebufferStartInfo(
 		string helperPath,
@@ -134,7 +137,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 		string source,
 		string? sourceDetail,
 		Action release,
-		CancellationToken cancellationToken)
+		CancellationToken cancellationToken,
+		TimeSpan startupTimeout)
 	{
 		var process = new Process { StartInfo = startInfo };
 		if (!process.Start())
@@ -146,7 +150,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 
 		try
 		{
-			var ready = await WaitForReadyAsync(process, cancellationToken).ConfigureAwait(false);
+			var ready = await WaitForReadyAsync(process, startupTimeout, cancellationToken)
+				.ConfigureAwait(false);
 			var session = new IosScreenCaptureVideoSession(
 				process,
 				new StreamDescriptor
@@ -174,10 +179,13 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 	/// The helper reports startup as newline-delimited JSON on stderr so stdout stays a byte-exact
 	/// Annex-B stream.
 	/// </summary>
-	private static async Task<ReadyEvent> WaitForReadyAsync(Process process, CancellationToken cancellationToken)
+	private static async Task<ReadyEvent> WaitForReadyAsync(
+		Process process,
+		TimeSpan startupTimeout,
+		CancellationToken cancellationToken)
 	{
 		using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		timeout.CancelAfter(TimeSpan.FromSeconds(15));
+		timeout.CancelAfter(startupTimeout);
 
 		try
 		{
@@ -215,7 +223,8 @@ internal sealed class IosScreenCaptureVideoSession : ILiveVideoSession
 		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
 		{
 			throw new TimeoutException(
-				$"{ScreenCaptureHelper.ExecutableName} did not start capturing within 15 seconds.");
+				$"{ScreenCaptureHelper.ExecutableName} did not start capturing within "
+				+ $"{startupTimeout.TotalSeconds:g} seconds.");
 		}
 	}
 

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -36,6 +36,9 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		new(StringComparer.OrdinalIgnoreCase);
 	private readonly SemaphoreSlim _inputRemovalGate = new(1, 1);
 	private static readonly TimeSpan BootedCacheLifetime = TimeSpan.FromSeconds(15);
+	private static readonly TimeSpan FramebufferStartupTimeout = TimeSpan.FromSeconds(15);
+	private static readonly TimeSpan FramebufferRetryTimeout = TimeSpan.FromSeconds(8);
+	private static readonly TimeSpan FramebufferRetryDelay = TimeSpan.FromMilliseconds(250);
 
 	public IosSimulatorBackend(IProcessRunner processRunner)
 		: this(
@@ -519,12 +522,15 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 			var device = await RequireBootedAsync(deviceId, cancellationToken).ConfigureAwait(false);
 			try
 			{
-				return await IosScreenCaptureVideoSession.StartFramebufferAsync(
-					helperPath,
-					device.NativeId,
-					options,
-					display,
-					static () => { },
+				return await StartFramebufferWithRetryAsync(
+					(startupTimeout, token) => IosScreenCaptureVideoSession.StartFramebufferAsync(
+						helperPath,
+						device.NativeId,
+						options,
+						display,
+						static () => { },
+						token,
+						startupTimeout),
 					cancellationToken).ConfigureAwait(false);
 			}
 			catch (Exception exception) when (exception is not OperationCanceledException)
@@ -584,6 +590,35 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 		catch (Exception exception) when (IdbCompanionManager.IsAvailabilityFailure(exception))
 		{
 			throw BuildVideoUnavailableException(nativeFailure, exception.Message);
+		}
+	}
+
+	internal static async Task<T> StartFramebufferWithRetryAsync<T>(
+		Func<TimeSpan, CancellationToken, Task<T>> start,
+		CancellationToken cancellationToken,
+		Func<TimeSpan, CancellationToken, Task>? delay = null)
+	{
+		try
+		{
+			return await start(FramebufferStartupTimeout, cancellationToken).ConfigureAwait(false);
+		}
+		catch (TimeoutException firstTimeout)
+		{
+			await (delay ?? Task.Delay)(FramebufferRetryDelay, cancellationToken).ConfigureAwait(false);
+			try
+			{
+				return await start(FramebufferRetryTimeout, cancellationToken).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
+			catch (Exception retryFailure)
+			{
+				throw new InvalidOperationException(
+					$"{firstTimeout.Message} Retry failed: {retryFailure.Message}",
+					retryFailure);
+			}
 		}
 	}
 

--- a/tests/MobileCanvas.Tests/NativeCaptureTests.cs
+++ b/tests/MobileCanvas.Tests/NativeCaptureTests.cs
@@ -102,6 +102,66 @@ public class NativeCaptureTests
 	}
 
 	[Fact]
+	public async Task FramebufferStartup_RetriesOneTimeoutThenSucceeds()
+	{
+		var attempts = new List<TimeSpan>();
+
+		var result = await IosSimulatorBackend.StartFramebufferWithRetryAsync(
+			(timeout, _) =>
+			{
+				attempts.Add(timeout);
+				return attempts.Count == 1
+					? Task.FromException<string>(new TimeoutException("first timeout"))
+					: Task.FromResult("framebuffer");
+			},
+			CancellationToken.None,
+			static (_, _) => Task.CompletedTask);
+
+		Assert.Equal("framebuffer", result);
+		Assert.Equal([TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(8)], attempts);
+	}
+
+	[Fact]
+	public async Task FramebufferStartup_DoesNotRetryExplicitFailure()
+	{
+		var attempts = 0;
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			IosSimulatorBackend.StartFramebufferWithRetryAsync<string>(
+				(_, _) =>
+				{
+					attempts++;
+					return Task.FromException<string>(new InvalidOperationException("unsupported"));
+				},
+				CancellationToken.None,
+				static (_, _) => Task.CompletedTask));
+
+		Assert.Equal("unsupported", exception.Message);
+		Assert.Equal(1, attempts);
+	}
+
+	[Fact]
+	public async Task FramebufferStartup_PreservesBothTimeoutFailures()
+	{
+		var attempts = 0;
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			IosSimulatorBackend.StartFramebufferWithRetryAsync<string>(
+				(_, _) =>
+				{
+					attempts++;
+					return Task.FromException<string>(
+						new TimeoutException(attempts == 1 ? "first timeout" : "second timeout"));
+				},
+				CancellationToken.None,
+				static (_, _) => Task.CompletedTask));
+
+		Assert.Contains("first timeout", exception.Message);
+		Assert.Contains("second timeout", exception.Message);
+		Assert.Equal(2, attempts);
+	}
+
+	[Fact]
 	public void VideoUnavailable_ReportsNativeAndOptionalIdbFailures()
 	{
 		var exception = IosSimulatorBackend.BuildVideoUnavailableException(

--- a/tests/web/platform-picker.test.mjs
+++ b/tests/web/platform-picker.test.mjs
@@ -13,7 +13,14 @@ test("destructive actions respect backend capabilities", () => {
   assert.equal(canUseDeviceCapability({ capabilities: {} }, "delete"), true);
 });
 
-test("diagnostic-only platforms remain visible after platforms with devices", () => {
+test("orders usable iOS before Android", () => {
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "android" }, { platform: "ios" }],
+    diagnostics: [{ platform: "ios", available: true, ready: false, checks: [] }],
+  }), ["ios", "android"]);
+});
+
+test("orders Android before unavailable iOS", () => {
   assert.deepEqual(catalogPlatforms({
     devices: [{ platform: "android" }],
     diagnostics: [{ platform: "ios", available: false, ready: false, checks: [] }],

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile-canvas",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile-canvas",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.3"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "mobile-canvas",
   "displayName": "Mobile Canvas",
   "description": "Run and control iOS Simulators and Android emulators in VS Code, with live video and Copilot-powered device automation.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "publisher": "redth",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/vscode/test/canvas-state.test.mjs
+++ b/vscode/test/canvas-state.test.mjs
@@ -248,14 +248,24 @@ test("keeps unsupported diagnostic actions in the selector", () => {
   assert.deepEqual(organizeDiagnostics(null), { notices: [], popover: [], unavailable: [] });
 });
 
-test("orders Android before diagnostic-only unavailable iOS", () => {
+test("orders usable iOS before Android", () => {
   assert.deepEqual(catalogPlatforms({
     devices: [{ platform: "ios" }, { platform: "android" }],
-    diagnostics: [{ platform: "ios", ready: false, checks: [] }],
+    diagnostics: [{ platform: "ios", available: true, ready: false, checks: [] }],
+  }), ["ios", "android"]);
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "android" }, { platform: "ios" }],
+  }), ["ios", "android"]);
+});
+
+test("orders Android before unavailable iOS", () => {
+  assert.deepEqual(catalogPlatforms({
+    devices: [{ platform: "ios" }, { platform: "android" }],
+    diagnostics: [{ platform: "ios", available: false, ready: false, checks: [] }],
   }), ["android", "ios"]);
   assert.deepEqual(catalogPlatforms({
     devices: [{ platform: "android" }],
-    diagnostics: [{ platform: "ios", ready: false, checks: [] }],
+    diagnostics: [{ platform: "ios", available: false, ready: false, checks: [] }],
   }), ["android", "ios"]);
 });
 

--- a/web/canvas-state.js
+++ b/web/canvas-state.js
@@ -91,7 +91,8 @@ export function createLatestCatalogLoader(fetchCatalog, applyCatalog) {
   };
 }
 
-const PLATFORM_ORDER = ["android", "ios"];
+const PLATFORM_ORDER = ["ios", "android"];
+const IOS_UNAVAILABLE_PLATFORM_ORDER = ["android", "ios"];
 
 export function catalogPlatforms(catalog) {
   const seen = new Set();
@@ -99,7 +100,11 @@ export function catalogPlatforms(catalog) {
   for (const runtime of catalog?.runtimes ?? []) addPlatform(seen, runtime?.platform);
   for (const diagnostic of catalog?.diagnostics ?? []) addPlatform(seen, diagnostic?.platform);
 
-  const known = PLATFORM_ORDER.filter((platform) => seen.has(platform));
+  const iosUnavailable = (catalog?.diagnostics ?? []).some(
+    (diagnostic) => platformKey(diagnostic?.platform) === "ios" && diagnostic?.available === false,
+  );
+  const order = iosUnavailable ? IOS_UNAVAILABLE_PLATFORM_ORDER : PLATFORM_ORDER;
+  const known = order.filter((platform) => seen.has(platform));
   const extra = [...seen].filter((platform) => !PLATFORM_ORDER.includes(platform)).sort();
   return [...known, ...extra];
 }
@@ -148,8 +153,12 @@ export function organizeDiagnostics(diagnostics) {
 }
 
 function addPlatform(platforms, value) {
-  const platform = String(value ?? "").trim().toLowerCase();
+  const platform = platformKey(value);
   if (platform) platforms.add(platform);
+}
+
+function platformKey(value) {
+  return String(value ?? "").trim().toLowerCase();
 }
 
 function hasActionLabel(action) {


### PR DESCRIPTION
## Summary

- retry transient iOS framebuffer startup timeouts before falling back to degraded capture paths
- keep iOS first in the shared device picker whenever the iOS toolchain is available
- avoid native helper test failures caused by early pipe closure
- stamp all packages and manifests as stable `0.1.18`
- refresh the checksummed runtime manifest from the cross-platform release build

## Validation

- `dotnet test MobileCanvas.slnx -c Release --nologo`
- `./native/mobile-screencap/test.sh --arch arm64`
- `./native/mobile-screencap/test.sh --arch x86_64`
- `npm test --prefix vscode`
- `node scripts/verify-bundle.mjs`
- `node scripts/source-hash.mjs --check`