### PR TITLE
Make recording finalization retry-safe

### DIFF
--- a/runtimes/manifest.json
+++ b/runtimes/manifest.json
@@ -3,82 +3,82 @@
     "darwin-arm64": {
       "rid": "osx-arm64",
       "executable": "mobile-canvas",
-      "id": "2600f796da7072f46ae5b46ad49f6dba1b8896c82df38f4558f066d45e28e90a",
+      "id": "8d82cd1f164df009c414b13f42be29b5e65d76f5cc04ac6665e8a0234e03ce63",
       "files": {
         "mobile-canvas": {
-          "sha256": "2600f796da7072f46ae5b46ad49f6dba1b8896c82df38f4558f066d45e28e90a",
-          "size": 32376720,
-          "asset": "mobile-canvas-v0.1.18-rc.1-osx-arm64.gz"
+          "sha256": "8d82cd1f164df009c414b13f42be29b5e65d76f5cc04ac6665e8a0234e03ce63",
+          "size": 32443152,
+          "asset": "mobile-canvas-v0.1.18-rc.2-osx-arm64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.18-rc.1-osx-arm64.gz"
+          "asset": "mobile-screencap-v0.1.18-rc.2-osx-arm64.gz"
         }
       }
     },
     "darwin-x64": {
       "rid": "osx-x64",
       "executable": "mobile-canvas",
-      "id": "0848812fadc3dba7c77e2b05d36920a0896ca4c8ea72d28e5cf3b26b18a1293d",
+      "id": "4185f46b1d56cfbc3c6253e6cbe5c0ab4afcbddfb23e76b017eab296b8cb0290",
       "files": {
         "mobile-canvas": {
-          "sha256": "0848812fadc3dba7c77e2b05d36920a0896ca4c8ea72d28e5cf3b26b18a1293d",
-          "size": 34131592,
-          "asset": "mobile-canvas-v0.1.18-rc.1-osx-x64.gz"
+          "sha256": "4185f46b1d56cfbc3c6253e6cbe5c0ab4afcbddfb23e76b017eab296b8cb0290",
+          "size": 34197480,
+          "asset": "mobile-canvas-v0.1.18-rc.2-osx-x64.gz"
         },
         "mobile-screencap": {
           "sha256": "43a70ef349786af22a6dfa211b9c9d487bf071f257ce3ffb5ae44d1112eda7da",
           "size": 969664,
-          "asset": "mobile-screencap-v0.1.18-rc.1-osx-x64.gz"
+          "asset": "mobile-screencap-v0.1.18-rc.2-osx-x64.gz"
         }
       }
     },
     "linux-arm64": {
       "rid": "linux-arm64",
       "executable": "mobile-canvas",
-      "id": "0e95d5ec10ec484f3f232f3f7a6d2172c7af066ebfcb6b005480a533fe08260e",
+      "id": "082d947bbc5e5062692b6ae21b837d12c24ed3fd3155dce716a1d0519e638458",
       "files": {
         "mobile-canvas": {
-          "sha256": "0e95d5ec10ec484f3f232f3f7a6d2172c7af066ebfcb6b005480a533fe08260e",
-          "size": 34485104,
-          "asset": "mobile-canvas-v0.1.18-rc.1-linux-arm64.gz"
+          "sha256": "082d947bbc5e5062692b6ae21b837d12c24ed3fd3155dce716a1d0519e638458",
+          "size": 34551880,
+          "asset": "mobile-canvas-v0.1.18-rc.2-linux-arm64.gz"
         }
       }
     },
     "linux-x64": {
       "rid": "linux-x64",
       "executable": "mobile-canvas",
-      "id": "8fa0132790887a4f0ed5b22b691b68b96f830c3954d8e694b82b306e5e7aa51f",
+      "id": "d53b53d1865bcea122b0e76c77d326aa21af32251e3e940420a3cc11e52ec93d",
       "files": {
         "mobile-canvas": {
-          "sha256": "8fa0132790887a4f0ed5b22b691b68b96f830c3954d8e694b82b306e5e7aa51f",
-          "size": 33792656,
-          "asset": "mobile-canvas-v0.1.18-rc.1-linux-x64.gz"
+          "sha256": "d53b53d1865bcea122b0e76c77d326aa21af32251e3e940420a3cc11e52ec93d",
+          "size": 33855328,
+          "asset": "mobile-canvas-v0.1.18-rc.2-linux-x64.gz"
         }
       }
     },
     "win32-arm64": {
       "rid": "win-arm64",
       "executable": "mobile-canvas.exe",
-      "id": "31daff6d2262337680596a6003ebdf8247eabee6ef6ad1012db1b374071757c1",
+      "id": "35152f60952adf2a79565b4c89f736399b2b7c437b3199c3ef3d80c671bced3f",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "31daff6d2262337680596a6003ebdf8247eabee6ef6ad1012db1b374071757c1",
-          "size": 38136320,
-          "asset": "mobile-canvas-v0.1.18-rc.1-win-arm64.gz"
+          "sha256": "35152f60952adf2a79565b4c89f736399b2b7c437b3199c3ef3d80c671bced3f",
+          "size": 38202368,
+          "asset": "mobile-canvas-v0.1.18-rc.2-win-arm64.gz"
         }
       }
     },
     "win32-x64": {
       "rid": "win-x64",
       "executable": "mobile-canvas.exe",
-      "id": "8e16a57d9d443679bb030cce3b55b87c50a4058a49a2c86716df31dc1d4e0a87",
+      "id": "182630fd519d4fc061d88ad060c0c8064e97616f346e788aba021239ee649329",
       "files": {
         "mobile-canvas.exe": {
-          "sha256": "8e16a57d9d443679bb030cce3b55b87c50a4058a49a2c86716df31dc1d4e0a87",
-          "size": 37436928,
-          "asset": "mobile-canvas-v0.1.18-rc.1-win-x64.gz"
+          "sha256": "182630fd519d4fc061d88ad060c0c8064e97616f346e788aba021239ee649329",
+          "size": 37500416,
+          "asset": "mobile-canvas-v0.1.18-rc.2-win-x64.gz"
         }
       }
     }
@@ -86,7 +86,7 @@
   "version": "0.1.18",
   "distribution": {
     "repository": "Redth/mobile-canvas-ghcp",
-    "tag": "v0.1.18-rc.1"
+    "tag": "v0.1.18-rc.2"
   },
-  "sourceHash": "340d390acd0d70dfc1db1106a7f99208a4ff0617efc7529c3315ef37363afb19"
+  "sourceHash": "2113fb9b31d653b17be0f32e65b2374340d5bd372de14c09c270a706147d26d3"
 }

--- a/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
+++ b/src/MobileCanvas.Android/AndroidEmulatorBackend.cs
@@ -690,7 +690,7 @@ public sealed partial class AndroidEmulatorBackend : IDeviceBackend, IAsyncDispo
 		if (instance is null)
 			return await GetDeviceAsync(deviceId, cancellationToken).ConfigureAwait(false);
 
-		await _recordings.StopQuietlyAsync(deviceId).ConfigureAwait(false);
+		await _recordings.FinalizeOrAbandonAsync(deviceId).ConfigureAwait(false);
 
 		var stopped = false;
 		if (instance.HasGrpc)

--- a/src/MobileCanvas.Android/AndroidRecordingManager.cs
+++ b/src/MobileCanvas.Android/AndroidRecordingManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using MobileCanvas.Contracts;
+using MobileCanvas.Core;
 using Microsoft.Extensions.Logging;
 
 namespace MobileCanvas.Android;
@@ -17,10 +18,37 @@ namespace MobileCanvas.Android;
 /// <c>screenrecord</c> stops on rotation and enforces its own limit, so the requested timeout is
 /// passed through as <c>--time-limit</c> as well as being enforced host-side.
 /// </remarks>
-internal sealed class AndroidRecordingManager(AndroidEmulatorBackend backend, ILogger logger) : IAsyncDisposable
+internal sealed class AndroidRecordingManager : IAsyncDisposable
 {
+	private static readonly TimeSpan StartSettleDelay = TimeSpan.FromMilliseconds(500);
+	private static readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(15);
+	private static readonly TimeSpan StableFilePollDelay = TimeSpan.FromMilliseconds(250);
+
+	private readonly IAndroidRecordingPlatform _platform;
+	private readonly ILogger _logger;
+	private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+	private readonly TimeSpan _processExitTimeout;
 	private readonly ConcurrentDictionary<string, ActiveRecording> _recordings =
 		new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, SemaphoreSlim> _startGates =
+		new(StringComparer.OrdinalIgnoreCase);
+
+	public AndroidRecordingManager(AndroidEmulatorBackend backend, ILogger logger)
+		: this(new AndroidRecordingPlatform(backend), logger)
+	{
+	}
+
+	internal AndroidRecordingManager(
+		IAndroidRecordingPlatform platform,
+		ILogger logger,
+		Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+		TimeSpan? processExitTimeout = null)
+	{
+		_platform = platform;
+		_logger = logger;
+		_delayAsync = delayAsync ?? Task.Delay;
+		_processExitTimeout = processExitTimeout ?? ProcessExitTimeout;
+	}
 
 	public async Task<RecordingStatus> StartAsync(
 		string deviceId,
@@ -34,140 +62,209 @@ internal sealed class AndroidRecordingManager(AndroidEmulatorBackend backend, IL
 				"Recording timeout must be between 1 and 3600 seconds.");
 		}
 
-		if (_recordings.ContainsKey(deviceId))
-			throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
-
-		var serial = await backend.RequireSerialAsync(deviceId, cancellationToken).ConfigureAwait(false);
-
-		var outputPath = string.IsNullOrWhiteSpace(request.OutputPath)
-			? CreateDefaultPath()
-			: Path.GetFullPath(request.OutputPath);
-		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-
-		var devicePath = $"/sdcard/mobile-canvas-recording-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.mp4";
-		var size = await ResolveRecordingSizeAsync(deviceId, cancellationToken).ConfigureAwait(false);
-		var process = StartScreenRecord(serial, devicePath, request.TimeoutSeconds, size);
-
-		var recording = new ActiveRecording(process, serial, devicePath, outputPath, request.TimeoutSeconds);
-		if (!_recordings.TryAdd(deviceId, recording))
-		{
-			AndroidVideoEncoder.TryKill(process);
-			process.Dispose();
-			throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
-		}
-
-		// screenrecord fails fast on a bad path or an unsupported resolution, so a short settle
-		// window turns a silent no-op into an actionable error.
-		await Task.Delay(500, cancellationToken).ConfigureAwait(false);
-		if (process.HasExited)
-		{
-			_recordings.TryRemove(deviceId, out _);
-			var detail = await ReadStandardErrorAsync(process).ConfigureAwait(false);
-			var exitCode = process.ExitCode;
-			process.Dispose();
-			throw new InvalidOperationException(
-				$"screenrecord exited before it started (code {exitCode}). {detail}".TrimEnd());
-		}
-
-		recording.TimeoutTask = StopAfterTimeoutAsync(deviceId, request.TimeoutSeconds);
-		return ToStatus(deviceId, recording, isRecording: true);
-	}
-
-	public async Task<RecordingStatus> StopAsync(string deviceId, CancellationToken cancellationToken)
-	{
-		if (!_recordings.TryRemove(deviceId, out var recording))
-			throw new InvalidOperationException($"No recording is active for '{deviceId}'.");
-
-		await recording.TimeoutCancellation.CancelAsync().ConfigureAwait(false);
-
+		var startGate = _startGates.GetOrAdd(deviceId, static _ => new SemaphoreSlim(1, 1));
+		await startGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
-			// screenrecord only writes the MP4 moov atom when it is interrupted, so it must be
-			// signalled on the device. Killing the host-side adb alone can leave an unplayable file.
-			await backend.RunAdbAsync(
-				recording.Serial,
-				["shell", "pkill", "-INT", "screenrecord"],
-				cancellationToken).ConfigureAwait(false);
+			if (_recordings.TryGetValue(deviceId, out var existing) && !existing.Finalizer.IsCompleted)
+				throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
 
-			try
+			var serial = await _platform.RequireSerialAsync(deviceId, cancellationToken).ConfigureAwait(false);
+			var outputPath = string.IsNullOrWhiteSpace(request.OutputPath)
+				? CreateDefaultPath()
+				: Path.GetFullPath(request.OutputPath);
+			Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+			var devicePath = $"/sdcard/mobile-canvas-recording-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}.mp4";
+			var temporaryPath = CreateTemporaryPath(outputPath);
+			var size = await ResolveRecordingSizeAsync(deviceId, cancellationToken).ConfigureAwait(false);
+			var process = _platform.StartScreenRecord(serial, devicePath, request.TimeoutSeconds, size);
+			var recording = new ActiveRecording(
+				process,
+				serial,
+				devicePath,
+				temporaryPath,
+				outputPath,
+				request.TimeoutSeconds);
+			_recordings[deviceId] = recording;
+
+			await _delayAsync(StartSettleDelay, cancellationToken).ConfigureAwait(false);
+			if (process.HasExited)
 			{
-				await recording.Process.WaitForExitAsync(cancellationToken)
-					.WaitAsync(TimeSpan.FromSeconds(15), cancellationToken)
-					.ConfigureAwait(false);
-			}
-			catch (TimeoutException)
-			{
-				AndroidVideoEncoder.TryKill(recording.Process);
-				logger.LogWarning("screenrecord did not stop within 15 seconds for {DeviceId}.", deviceId);
+				_recordings.TryRemove(new KeyValuePair<string, ActiveRecording>(deviceId, recording));
+				var detail = await process.ReadStandardErrorAsync().ConfigureAwait(false);
+				var exitCode = process.ExitCode;
+				process.Dispose();
+				throw new InvalidOperationException(
+					$"screenrecord exited before it started (code {exitCode}). {detail}".TrimEnd());
 			}
 
-			// The encoder flushes asynchronously after the signal, so pulling immediately can capture
-			// a truncated file.
-			await WaitForStableFileAsync(recording, cancellationToken).ConfigureAwait(false);
-			await PullAsync(recording, cancellationToken).ConfigureAwait(false);
+			recording.TimeoutTask = StopAfterTimeoutAsync(deviceId, recording);
+			return ToStatus(deviceId, recording, isRecording: true);
 		}
 		finally
 		{
-			recording.Process.Dispose();
-			recording.TimeoutCancellation.Dispose();
-
-			try
-			{
-				await backend.RunAdbAsync(
-					recording.Serial,
-					["shell", "rm", "-f", recording.DevicePath],
-					CancellationToken.None).ConfigureAwait(false);
-			}
-			catch (Exception exception)
-			{
-				logger.LogDebug(exception, "Could not remove the on-device recording {Path}.", recording.DevicePath);
-			}
+			startGate.Release();
 		}
+	}
 
-		return ToStatus(deviceId, recording, isRecording: false);
+	public Task<RecordingStatus> StopAsync(string deviceId, CancellationToken cancellationToken)
+	{
+		if (!_recordings.TryGetValue(deviceId, out var recording))
+			throw new InvalidOperationException($"No recording is active for '{deviceId}'.");
+
+		return recording.Finalizer.FinalizeAsync(
+			token => FinalizeAsync(deviceId, recording, token),
+			cancellationToken);
 	}
 
 	/// <summary>
-	/// Stops a recording without surfacing failures, for paths such as shutdown where the recording
-	/// is incidental to what the caller asked for.
+	/// Finalizes a recording if possible, then explicitly abandons and cleans it up before its device
+	/// is stopped or the backend is disposed.
 	/// </summary>
-	public async Task StopQuietlyAsync(string deviceId)
+	public async Task FinalizeOrAbandonAsync(string deviceId)
 	{
-		if (!_recordings.ContainsKey(deviceId))
+		if (!_recordings.TryGetValue(deviceId, out var recording) || recording.Finalizer.IsCompleted)
 			return;
 
 		try
 		{
 			await StopAsync(deviceId, CancellationToken.None).ConfigureAwait(false);
+			return;
 		}
 		catch (Exception exception)
 		{
-			logger.LogWarning(exception, "Failed to stop the recording for {DeviceId}.", deviceId);
+			_logger.LogWarning(exception, "Failed to finalize the recording for {DeviceId}; abandoning it.", deviceId);
 		}
+
+		await AbandonAsync(deviceId, recording).ConfigureAwait(false);
 	}
 
-	public RecordingStatus GetStatus(string deviceId) =>
-		_recordings.TryGetValue(deviceId, out var recording) && !recording.Process.HasExited
-			? ToStatus(deviceId, recording, isRecording: true)
-			: new RecordingStatus { DeviceId = deviceId };
+	internal async Task AbandonAsync(string deviceId)
+	{
+		if (_recordings.TryGetValue(deviceId, out var recording))
+			await AbandonAsync(deviceId, recording).ConfigureAwait(false);
+	}
+
+	public RecordingStatus GetStatus(string deviceId)
+	{
+		if (!_recordings.TryGetValue(deviceId, out var recording))
+			return new RecordingStatus { DeviceId = deviceId };
+		return recording.Finalizer.CompletedStatus ?? ToStatus(deviceId, recording, isRecording: true);
+	}
 
 	public async ValueTask DisposeAsync()
 	{
 		foreach (var deviceId in _recordings.Keys.ToArray())
-			await StopQuietlyAsync(deviceId).ConfigureAwait(false);
+			await FinalizeOrAbandonAsync(deviceId).ConfigureAwait(false);
+
+		foreach (var gate in _startGates.Values)
+			gate.Dispose();
+		_startGates.Clear();
 	}
 
-	/// <summary>
-	/// Picks an explicit <c>--size</c> for screenrecord.
-	/// </summary>
-	/// <remarks>
-	/// Left to itself, screenrecord silently falls back to a 720x1280 default when the display
-	/// exceeds what the on-device encoder advertises. On a tall modern AVD (1344x2992) that is a
-	/// different aspect ratio, so the recording comes out visibly stretched. Deriving the size from
-	/// the real display keeps the aspect ratio, and capping the long edge keeps it inside the AVC
-	/// level limits that caused the fallback in the first place. Returning null on any failure means
-	/// a device we cannot measure simply records the way it did before.
-	/// </remarks>
+	private async Task<RecordingStatus> FinalizeAsync(
+		string deviceId,
+		ActiveRecording recording,
+		CancellationToken cancellationToken)
+	{
+		await recording.TimeoutCancellation.CancelAsync().ConfigureAwait(false);
+
+		if (!recording.Process.HasExited)
+		{
+			if (!recording.StopSignalSent)
+			{
+				// screenrecord only writes the MP4 moov atom when interrupted on the device.
+				var output = await _platform.RunAdbAsync(
+					recording.Serial,
+					["shell", "pkill", "-INT", "screenrecord"],
+					cancellationToken).ConfigureAwait(false);
+				if (output is null)
+					throw new InvalidOperationException("Could not interrupt screenrecord on the emulator.");
+				recording.StopSignalSent = true;
+			}
+
+			await recording.Process.WaitForExitAsync(cancellationToken)
+				.WaitAsync(_processExitTimeout, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		await WaitForStableFileAsync(recording, cancellationToken).ConfigureAwait(false);
+		await PullAsync(recording, cancellationToken).ConfigureAwait(false);
+		ValidateRecording(recording.TemporaryPath);
+		File.Move(recording.TemporaryPath, recording.OutputPath, overwrite: true);
+
+		var completed = ToStatus(deviceId, recording, isRecording: false);
+		await CleanupAfterSuccessAsync(recording).ConfigureAwait(false);
+		return completed;
+	}
+
+	private async Task AbandonAsync(string deviceId, ActiveRecording recording)
+	{
+		await recording.Finalizer.AbandonAsync(async () =>
+		{
+			await recording.TimeoutCancellation.CancelAsync().ConfigureAwait(false);
+
+			if (!recording.Process.HasExited)
+			{
+				using var cleanupTimeout = new CancellationTokenSource(_processExitTimeout);
+				try
+				{
+					await _platform.RunAdbAsync(
+						recording.Serial,
+						["shell", "pkill", "-INT", "screenrecord"],
+						cleanupTimeout.Token).ConfigureAwait(false);
+				}
+				catch (Exception exception)
+				{
+					_logger.LogDebug(exception, "Could not interrupt screenrecord for {DeviceId}.", deviceId);
+				}
+				recording.Process.Kill();
+			}
+
+			await CleanupOwnedFilesAsync(recording).ConfigureAwait(false);
+			recording.Process.Dispose();
+			recording.TimeoutCancellation.Dispose();
+			_recordings.TryRemove(new KeyValuePair<string, ActiveRecording>(deviceId, recording));
+		}).ConfigureAwait(false);
+	}
+
+	private async Task CleanupAfterSuccessAsync(ActiveRecording recording)
+	{
+		recording.Process.Dispose();
+		recording.TimeoutCancellation.Dispose();
+		await RemoveDeviceFileAsync(recording).ConfigureAwait(false);
+	}
+
+	private async Task CleanupOwnedFilesAsync(ActiveRecording recording)
+	{
+		await RemoveDeviceFileAsync(recording).ConfigureAwait(false);
+		try
+		{
+			File.Delete(recording.TemporaryPath);
+		}
+		catch (Exception exception)
+		{
+			_logger.LogDebug(exception, "Could not remove temporary recording {Path}.", recording.TemporaryPath);
+		}
+	}
+
+	private async Task RemoveDeviceFileAsync(ActiveRecording recording)
+	{
+		using var cleanupTimeout = new CancellationTokenSource(_processExitTimeout);
+		try
+		{
+			await _platform.RunAdbAsync(
+				recording.Serial,
+				["shell", "rm", "-f", recording.DevicePath],
+				cleanupTimeout.Token).ConfigureAwait(false);
+		}
+		catch (Exception exception)
+		{
+			_logger.LogDebug(exception, "Could not remove the on-device recording {Path}.", recording.DevicePath);
+		}
+	}
+
 	private async Task<(int Width, int Height)?> ResolveRecordingSizeAsync(
 		string deviceId,
 		CancellationToken cancellationToken)
@@ -176,9 +273,9 @@ internal sealed class AndroidRecordingManager(AndroidEmulatorBackend backend, IL
 
 		try
 		{
-			var display = await backend.GetDisplayAsync(deviceId, cancellationToken).ConfigureAwait(false);
-			var width = display.PixelWidth;
-			var height = display.PixelHeight;
+			var display = await _platform.GetDisplaySizeAsync(deviceId, cancellationToken).ConfigureAwait(false);
+			var width = display.Width;
+			var height = display.Height;
 			if (width <= 0 || height <= 0)
 				return null;
 
@@ -190,127 +287,86 @@ internal sealed class AndroidRecordingManager(AndroidEmulatorBackend backend, IL
 				height = (int)Math.Round(height * factor);
 			}
 
-			// The encoder needs even dimensions for the same chroma-subsampling reason the live
-			// stream does.
 			width -= width % 2;
 			height -= height % 2;
-
 			return width >= 2 && height >= 2 ? (width, height) : null;
 		}
 		catch (Exception exception) when (exception is not OperationCanceledException)
 		{
-			logger.LogDebug(exception, "Could not resolve a recording size for {DeviceId}.", deviceId);
+			_logger.LogDebug(exception, "Could not resolve a recording size for {DeviceId}.", deviceId);
 			return null;
 		}
 	}
 
-	private Process StartScreenRecord(
-		string serial,
-		string devicePath,
-		int timeoutSeconds,
-		(int Width, int Height)? size)
-	{
-		var adb = backend.AdbPath
-			?? throw new InvalidOperationException("adb was not found, so recording is unavailable.");
-
-		var startInfo = new ProcessStartInfo(adb)
-		{
-			UseShellExecute = false,
-			CreateNoWindow = true,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-		};
-
-		var arguments = new List<string>
-		{
-			"-s", serial, "shell", "screenrecord", "--time-limit", timeoutSeconds.ToString(),
-		};
-
-		if (size is { } resolved)
-		{
-			arguments.Add("--size");
-			arguments.Add($"{resolved.Width}x{resolved.Height}");
-		}
-
-		arguments.Add(devicePath);
-
-		foreach (var argument in arguments)
-			startInfo.ArgumentList.Add(argument);
-
-		return Process.Start(startInfo)
-			?? throw new InvalidOperationException("Failed to start screenrecord.");
-	}
-
-	private async Task WaitForStableFileAsync(ActiveRecording recording, CancellationToken cancellationToken)
+	private async Task WaitForStableFileAsync(
+		ActiveRecording recording,
+		CancellationToken cancellationToken)
 	{
 		long previous = -1;
-
 		for (var attempt = 0; attempt < 10; attempt++)
 		{
-			var output = await backend.RunAdbAsync(
+			var output = await _platform.RunAdbAsync(
 				recording.Serial,
 				["shell", "stat", "-c", "%s", recording.DevicePath],
 				cancellationToken).ConfigureAwait(false);
-
 			if (!long.TryParse(output?.Trim(), out var size))
-				return;
-
+				throw new InvalidOperationException($"Could not read the size of '{recording.DevicePath}'.");
 			if (size > 0 && size == previous)
 				return;
 
 			previous = size;
-			await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+			await _delayAsync(StableFilePollDelay, cancellationToken).ConfigureAwait(false);
 		}
+
+		throw new InvalidOperationException($"The recording '{recording.DevicePath}' did not become stable.");
 	}
 
 	private async Task PullAsync(ActiveRecording recording, CancellationToken cancellationToken)
 	{
-		var output = await backend.RunAdbAsync(
+		var output = await _platform.RunAdbAsync(
 			recording.Serial,
-			["pull", recording.DevicePath, recording.OutputPath],
+			["pull", recording.DevicePath, recording.TemporaryPath],
 			cancellationToken).ConfigureAwait(false);
-
-		if (output is null || !File.Exists(recording.OutputPath))
+		if (output is null || !File.Exists(recording.TemporaryPath))
 		{
 			throw new InvalidOperationException(
 				$"The recording could not be copied from the emulator to '{recording.OutputPath}'.");
 		}
 	}
 
-	private async Task StopAfterTimeoutAsync(string deviceId, int timeoutSeconds)
+	private async Task StopAfterTimeoutAsync(string deviceId, ActiveRecording recording)
 	{
-		if (!_recordings.TryGetValue(deviceId, out var recording))
-			return;
-
 		try
 		{
-			await Task.Delay(
-				TimeSpan.FromSeconds(timeoutSeconds),
+			await _delayAsync(
+				TimeSpan.FromSeconds(recording.TimeoutSeconds),
 				recording.TimeoutCancellation.Token).ConfigureAwait(false);
-			await StopQuietlyAsync(deviceId).ConfigureAwait(false);
+			if (_recordings.TryGetValue(deviceId, out var current) && ReferenceEquals(current, recording))
+			{
+				await recording.Finalizer.FinalizeAsync(
+					token => FinalizeAsync(deviceId, recording, token),
+					CancellationToken.None).ConfigureAwait(false);
+			}
 		}
 		catch (OperationCanceledException) when (recording.TimeoutCancellation.IsCancellationRequested)
 		{
-			// Stopped manually before the timeout elapsed.
 		}
 		catch (Exception exception)
 		{
-			logger.LogError(exception, "Timed recording stop failed for {DeviceId}.", deviceId);
+			_logger.LogError(exception, "Timed recording finalization failed for {DeviceId}.", deviceId);
 		}
 	}
 
-	private static async Task<string> ReadStandardErrorAsync(Process process)
+	private static void ValidateRecording(string path)
 	{
-		try
-		{
-			var text = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
-			return text.Trim();
-		}
-		catch (Exception)
-		{
-			return "";
-		}
+		if (!File.Exists(path) || new FileInfo(path).Length == 0)
+			throw new InvalidOperationException($"The finalized recording '{path}' is empty or missing.");
 	}
+
+	private static string CreateTemporaryPath(string outputPath) =>
+		Path.Combine(
+			Path.GetDirectoryName(outputPath)!,
+			$".{Path.GetFileName(outputPath)}.{Guid.NewGuid():N}.partial");
 
 	private static string CreateDefaultPath()
 	{
@@ -333,19 +389,91 @@ internal sealed class AndroidRecordingManager(AndroidEmulatorBackend backend, IL
 	};
 
 	private sealed class ActiveRecording(
-		Process process,
+		IRecordingProcess process,
 		string serial,
 		string devicePath,
+		string temporaryPath,
 		string outputPath,
 		int timeoutSeconds)
 	{
-		public Process Process { get; } = process;
+		public IRecordingProcess Process { get; } = process;
 		public string Serial { get; } = serial;
 		public string DevicePath { get; } = devicePath;
+		public string TemporaryPath { get; } = temporaryPath;
 		public string OutputPath { get; } = outputPath;
 		public DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
 		public int TimeoutSeconds { get; } = timeoutSeconds;
 		public CancellationTokenSource TimeoutCancellation { get; } = new();
+		public RecordingFinalizer Finalizer { get; } = new();
+		public bool StopSignalSent { get; set; }
 		public Task? TimeoutTask { get; set; }
 	}
+}
+
+internal interface IAndroidRecordingPlatform
+{
+	Task<string> RequireSerialAsync(string deviceId, CancellationToken cancellationToken);
+	Task<(int Width, int Height)> GetDisplaySizeAsync(string deviceId, CancellationToken cancellationToken);
+	IRecordingProcess StartScreenRecord(
+		string serial,
+		string devicePath,
+		int timeoutSeconds,
+		(int Width, int Height)? size);
+	Task<string?> RunAdbAsync(
+		string serial,
+		IReadOnlyList<string> arguments,
+		CancellationToken cancellationToken);
+}
+
+internal sealed class AndroidRecordingPlatform(AndroidEmulatorBackend backend) : IAndroidRecordingPlatform
+{
+	public Task<string> RequireSerialAsync(string deviceId, CancellationToken cancellationToken) =>
+		backend.RequireSerialAsync(deviceId, cancellationToken);
+
+	public async Task<(int Width, int Height)> GetDisplaySizeAsync(
+		string deviceId,
+		CancellationToken cancellationToken)
+	{
+		var display = await backend.GetDisplayAsync(deviceId, cancellationToken).ConfigureAwait(false);
+		return (display.PixelWidth, display.PixelHeight);
+	}
+
+	public IRecordingProcess StartScreenRecord(
+		string serial,
+		string devicePath,
+		int timeoutSeconds,
+		(int Width, int Height)? size)
+	{
+		var adb = backend.AdbPath
+			?? throw new InvalidOperationException("adb was not found, so recording is unavailable.");
+		var startInfo = new ProcessStartInfo(adb)
+		{
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+		};
+		var arguments = new List<string>
+		{
+			"-s", serial, "shell", "screenrecord", "--time-limit", timeoutSeconds.ToString(),
+		};
+		if (size is { } resolved)
+		{
+			arguments.Add("--size");
+			arguments.Add($"{resolved.Width}x{resolved.Height}");
+		}
+		arguments.Add(devicePath);
+		foreach (var argument in arguments)
+			startInfo.ArgumentList.Add(argument);
+
+		return new SystemRecordingProcess(
+			Process.Start(startInfo)
+				?? throw new InvalidOperationException("Failed to start screenrecord."));
+	}
+
+	public Task<string?> RunAdbAsync(
+		string serial,
+		IReadOnlyList<string> arguments,
+		CancellationToken cancellationToken) =>
+		backend.RunAdbAsync(serial, arguments.ToArray(), cancellationToken);
 }

--- a/src/MobileCanvas.Core/MobileCanvas.Core.csproj
+++ b/src/MobileCanvas.Core/MobileCanvas.Core.csproj
@@ -7,6 +7,8 @@
     <ProjectReference Include="../MobileCanvas.Contracts/MobileCanvas.Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MobileCanvas.Android" />
+    <InternalsVisibleTo Include="MobileCanvas.iOS" />
     <InternalsVisibleTo Include="MobileCanvas.Tests" />
   </ItemGroup>
 </Project>

--- a/src/MobileCanvas.Core/RecordingFinalizer.cs
+++ b/src/MobileCanvas.Core/RecordingFinalizer.cs
@@ -1,0 +1,143 @@
+using System.Diagnostics;
+using MobileCanvas.Contracts;
+
+namespace MobileCanvas.Core;
+
+internal sealed class RecordingFinalizer
+{
+	private readonly object _sync = new();
+	private Task<RecordingStatus>? _attempt;
+	private CancellationTokenSource? _attemptCancellation;
+	private Task? _abandonTask;
+	private RecordingStatus? _completed;
+	private bool _abandonRequested;
+
+	public bool IsCompleted
+	{
+		get
+		{
+			lock (_sync)
+				return _completed is not null;
+		}
+	}
+
+	public RecordingStatus? CompletedStatus
+	{
+		get
+		{
+			lock (_sync)
+				return _completed;
+		}
+	}
+
+	public Task<RecordingStatus> FinalizeAsync(
+		Func<CancellationToken, Task<RecordingStatus>> finalize,
+		CancellationToken cancellationToken)
+	{
+		Task<RecordingStatus> attempt;
+		lock (_sync)
+		{
+			if (_completed is { } completed)
+				return Task.FromResult(completed);
+			if (_abandonRequested)
+				throw new InvalidOperationException("The recording is being abandoned.");
+
+			if (_attempt is null || (_attempt.IsCompleted && !_attempt.IsCompletedSuccessfully))
+			{
+				_attemptCancellation?.Dispose();
+				_attemptCancellation = new CancellationTokenSource();
+				_attempt = RunFinalizeAsync(finalize, _attemptCancellation.Token);
+			}
+			attempt = _attempt;
+		}
+
+		return attempt.WaitAsync(cancellationToken);
+	}
+
+	public async Task AbandonAsync(Func<Task> abandon)
+	{
+		Task<RecordingStatus>? attempt;
+		CancellationTokenSource? attemptCancellation;
+		lock (_sync)
+		{
+			if (_completed is not null)
+				return;
+
+			_abandonRequested = true;
+			attempt = _attempt;
+			attemptCancellation = _attemptCancellation;
+		}
+
+		if (attempt is not null)
+		{
+			await attemptCancellation!.CancelAsync().ConfigureAwait(false);
+			await attempt.ContinueWith(
+				static completedTask => _ = completedTask.Exception,
+				CancellationToken.None,
+				TaskContinuationOptions.ExecuteSynchronously,
+				TaskScheduler.Default).ConfigureAwait(false);
+		}
+
+		Task abandonTask;
+		lock (_sync)
+		{
+			if (_completed is not null)
+				return;
+
+			_abandonTask ??= abandon();
+			abandonTask = _abandonTask;
+		}
+
+		await abandonTask.ConfigureAwait(false);
+	}
+
+	private async Task<RecordingStatus> RunFinalizeAsync(
+		Func<CancellationToken, Task<RecordingStatus>> finalize,
+		CancellationToken cancellationToken)
+	{
+		var completed = await finalize(cancellationToken).ConfigureAwait(false);
+		lock (_sync)
+			_completed = completed;
+		return completed;
+	}
+}
+
+internal interface IRecordingProcess : IDisposable
+{
+	bool HasExited { get; }
+	int ExitCode { get; }
+	int Id { get; }
+	void Kill();
+	Task<string> ReadStandardErrorAsync();
+	Task WaitForExitAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class SystemRecordingProcess(Process process) : IRecordingProcess
+{
+	public bool HasExited => process.HasExited;
+	public int ExitCode => process.ExitCode;
+	public int Id => process.Id;
+
+	public void Dispose() => process.Dispose();
+
+	public void Kill()
+	{
+		if (!process.HasExited)
+			process.Kill(entireProcessTree: true);
+	}
+
+	public async Task<string> ReadStandardErrorAsync()
+	{
+		try
+		{
+			return (await process.StandardError.ReadToEndAsync().ConfigureAwait(false)).Trim();
+		}
+		catch (InvalidOperationException)
+		{
+			return "";
+		}
+	}
+
+	public Task WaitForExitAsync(CancellationToken cancellationToken) =>
+		process.WaitForExitAsync(cancellationToken);
+}

--- a/src/MobileCanvas.iOS/IosRecordingManager.cs
+++ b/src/MobileCanvas.iOS/IosRecordingManager.cs
@@ -5,10 +5,33 @@ using MobileCanvas.Core;
 
 namespace MobileCanvas.iOS;
 
-internal sealed class IosRecordingManager(IProcessRunner processRunner) : IAsyncDisposable
+internal sealed class IosRecordingManager : IAsyncDisposable
 {
+	private static readonly TimeSpan StartSettleDelay = TimeSpan.FromMilliseconds(500);
+	private static readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(15);
+
+	private readonly IIosRecordingPlatform _platform;
+	private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+	private readonly TimeSpan _processExitTimeout;
 	private readonly ConcurrentDictionary<string, ActiveRecording> _recordings =
 		new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, SemaphoreSlim> _startGates =
+		new(StringComparer.OrdinalIgnoreCase);
+
+	public IosRecordingManager(IProcessRunner processRunner)
+		: this(new IosRecordingPlatform(processRunner))
+	{
+	}
+
+	internal IosRecordingManager(
+		IIosRecordingPlatform platform,
+		Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+		TimeSpan? processExitTimeout = null)
+	{
+		_platform = platform;
+		_delayAsync = delayAsync ?? Task.Delay;
+		_processExitTimeout = processExitTimeout ?? ProcessExitTimeout;
+	}
 
 	public async Task<RecordingStatus> StartAsync(
 		string deviceId,
@@ -17,142 +40,192 @@ internal sealed class IosRecordingManager(IProcessRunner processRunner) : IAsync
 		CancellationToken cancellationToken)
 	{
 		if (request.TimeoutSeconds is < 1 or > 3600)
+		{
 			throw new ArgumentOutOfRangeException(
 				nameof(request),
 				"Recording timeout must be between 1 and 3600 seconds.");
-		if (_recordings.TryGetValue(deviceId, out var active) && !active.Process.HasExited)
-			throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
-
-		var outputPath = string.IsNullOrWhiteSpace(request.OutputPath)
-			? CreateDefaultPath()
-			: Path.GetFullPath(request.OutputPath);
-		Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-
-		var startInfo = new ProcessStartInfo
-		{
-			FileName = "xcrun",
-			UseShellExecute = false,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			CreateNoWindow = true,
-		};
-		foreach (var argument in new[]
-		{
-			"simctl", "io", udid, "recordVideo", "--codec=h264", "--force", outputPath,
-		})
-		{
-			startInfo.ArgumentList.Add(argument);
 		}
 
-		var process = Process.Start(startInfo)
-			?? throw new InvalidOperationException("Failed to start simctl screen recording.");
-		process.OutputDataReceived += (_, _) => { };
-		process.ErrorDataReceived += (_, _) => { };
-		process.BeginOutputReadLine();
-		process.BeginErrorReadLine();
-		var startedAt = DateTimeOffset.UtcNow;
-		var recording = new ActiveRecording(process, outputPath, startedAt, request.TimeoutSeconds);
-		if (!_recordings.TryAdd(deviceId, recording))
-		{
-			process.Kill(entireProcessTree: true);
-			process.Dispose();
-			throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
-		}
-
-		await Task.Delay(500, cancellationToken).ConfigureAwait(false);
-		if (process.HasExited)
-		{
-			_recordings.TryRemove(deviceId, out _);
-			var exitCode = process.ExitCode;
-			process.Dispose();
-			throw new InvalidOperationException(
-				$"simctl screen recording exited before it started (code {exitCode}).");
-		}
-
-		recording.TimeoutTask = StopAfterTimeoutAsync(deviceId, request.TimeoutSeconds);
-		return ToStatus(deviceId, recording, isRecording: true);
-	}
-
-	public async Task<RecordingStatus> StopAsync(string deviceId, CancellationToken cancellationToken)
-	{
-		if (!_recordings.TryRemove(deviceId, out var recording))
-			throw new InvalidOperationException($"No recording is active for '{deviceId}'.");
-
-		recording.TimeoutCancellation.Cancel();
+		var startGate = _startGates.GetOrAdd(deviceId, static _ => new SemaphoreSlim(1, 1));
+		await startGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
-			if (!recording.Process.HasExited)
-			{
-				var arguments = new[] { "-INT", recording.Process.Id.ToString() };
-				var result = await processRunner.RunAsync(
-					new ProcessRequest("kill", arguments),
-					cancellationToken).ConfigureAwait(false);
-				if (result.ExitCode != 0)
-					throw new ProcessExecutionException("kill", arguments, result);
+			if (_recordings.TryGetValue(deviceId, out var existing) && !existing.Finalizer.IsCompleted)
+				throw new InvalidOperationException($"A recording is already active for '{deviceId}'.");
 
-				try
-				{
-					await recording.Process.WaitForExitAsync(cancellationToken)
-						.WaitAsync(TimeSpan.FromSeconds(15), cancellationToken)
-						.ConfigureAwait(false);
-				}
-				catch (TimeoutException)
-				{
-					recording.Process.Kill(entireProcessTree: true);
-					throw new TimeoutException("simctl did not finalize the recording within 15 seconds.");
-				}
+			var outputPath = string.IsNullOrWhiteSpace(request.OutputPath)
+				? CreateDefaultPath()
+				: Path.GetFullPath(request.OutputPath);
+			Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+			var temporaryPath = CreateTemporaryPath(outputPath);
+			var process = _platform.StartRecording(udid, temporaryPath);
+			var recording = new ActiveRecording(
+				process,
+				temporaryPath,
+				outputPath,
+				DateTimeOffset.UtcNow,
+				request.TimeoutSeconds);
+			_recordings[deviceId] = recording;
+
+			await _delayAsync(StartSettleDelay, cancellationToken).ConfigureAwait(false);
+			if (process.HasExited)
+			{
+				_recordings.TryRemove(new KeyValuePair<string, ActiveRecording>(deviceId, recording));
+				var exitCode = process.ExitCode;
+				process.Dispose();
+				File.Delete(temporaryPath);
+				throw new InvalidOperationException(
+					$"simctl screen recording exited before it started (code {exitCode}).");
 			}
+
+			recording.TimeoutTask = StopAfterTimeoutAsync(deviceId, recording);
+			return ToStatus(deviceId, recording, isRecording: true);
 		}
 		finally
 		{
-			recording.Process.Dispose();
-			recording.TimeoutCancellation.Dispose();
+			startGate.Release();
+		}
+	}
+
+	public Task<RecordingStatus> StopAsync(string deviceId, CancellationToken cancellationToken)
+	{
+		if (!_recordings.TryGetValue(deviceId, out var recording))
+			throw new InvalidOperationException($"No recording is active for '{deviceId}'.");
+
+		return recording.Finalizer.FinalizeAsync(
+			token => FinalizeAsync(deviceId, recording, token),
+			cancellationToken);
+	}
+
+	public async Task FinalizeOrAbandonAsync(string deviceId)
+	{
+		if (!_recordings.TryGetValue(deviceId, out var recording) || recording.Finalizer.IsCompleted)
+			return;
+
+		try
+		{
+			await StopAsync(deviceId, CancellationToken.None).ConfigureAwait(false);
+			return;
+		}
+		catch (Exception exception)
+		{
+			Trace.TraceError(
+				"Failed to finalize recording for {0}; abandoning it: {1}",
+				deviceId,
+				exception);
 		}
 
-		return ToStatus(deviceId, recording, isRecording: false);
+		await AbandonAsync(deviceId, recording).ConfigureAwait(false);
+	}
+
+	internal async Task AbandonAsync(string deviceId)
+	{
+		if (_recordings.TryGetValue(deviceId, out var recording))
+			await AbandonAsync(deviceId, recording).ConfigureAwait(false);
 	}
 
 	public RecordingStatus GetStatus(string deviceId)
 	{
-		if (!_recordings.TryGetValue(deviceId, out var recording) || recording.Process.HasExited)
+		if (!_recordings.TryGetValue(deviceId, out var recording))
 			return new RecordingStatus { DeviceId = deviceId };
-		return ToStatus(deviceId, recording, isRecording: true);
+		return recording.Finalizer.CompletedStatus ?? ToStatus(deviceId, recording, isRecording: true);
 	}
 
 	public async ValueTask DisposeAsync()
 	{
 		foreach (var deviceId in _recordings.Keys.ToArray())
+			await FinalizeOrAbandonAsync(deviceId).ConfigureAwait(false);
+
+		foreach (var gate in _startGates.Values)
+			gate.Dispose();
+		_startGates.Clear();
+	}
+
+	private async Task<RecordingStatus> FinalizeAsync(
+		string deviceId,
+		ActiveRecording recording,
+		CancellationToken cancellationToken)
+	{
+		await recording.TimeoutCancellation.CancelAsync().ConfigureAwait(false);
+
+		if (!recording.Process.HasExited)
 		{
+			if (!recording.StopSignalSent)
+			{
+				await _platform.SendInterruptAsync(recording.Process.Id, cancellationToken)
+					.ConfigureAwait(false);
+				recording.StopSignalSent = true;
+			}
+
+			await recording.Process.WaitForExitAsync(cancellationToken)
+				.WaitAsync(_processExitTimeout, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		ValidateRecording(recording.TemporaryPath);
+		File.Move(recording.TemporaryPath, recording.OutputPath, overwrite: true);
+		var completed = ToStatus(deviceId, recording, isRecording: false);
+		recording.Process.Dispose();
+		recording.TimeoutCancellation.Dispose();
+		return completed;
+	}
+
+	private async Task AbandonAsync(string deviceId, ActiveRecording recording)
+	{
+		await recording.Finalizer.AbandonAsync(async () =>
+		{
+			await recording.TimeoutCancellation.CancelAsync().ConfigureAwait(false);
+			recording.Process.Kill();
+			recording.Process.Dispose();
+			recording.TimeoutCancellation.Dispose();
 			try
 			{
-				await StopAsync(deviceId, CancellationToken.None).ConfigureAwait(false);
+				File.Delete(recording.TemporaryPath);
 			}
 			catch (Exception exception)
 			{
-				Trace.TraceError("Failed to stop recording for {0}: {1}", deviceId, exception);
+				Trace.TraceError(
+					"Could not remove temporary recording {0}: {1}",
+					recording.TemporaryPath,
+					exception);
 			}
-		}
+			_recordings.TryRemove(new KeyValuePair<string, ActiveRecording>(deviceId, recording));
+		}).ConfigureAwait(false);
 	}
 
-	private async Task StopAfterTimeoutAsync(string deviceId, int timeoutSeconds)
+	private async Task StopAfterTimeoutAsync(string deviceId, ActiveRecording recording)
 	{
-		if (!_recordings.TryGetValue(deviceId, out var recording))
-			return;
 		try
 		{
-			await Task.Delay(
-				TimeSpan.FromSeconds(timeoutSeconds),
+			await _delayAsync(
+				TimeSpan.FromSeconds(recording.TimeoutSeconds),
 				recording.TimeoutCancellation.Token).ConfigureAwait(false);
-			await StopAsync(deviceId, CancellationToken.None).ConfigureAwait(false);
+			if (_recordings.TryGetValue(deviceId, out var current) && ReferenceEquals(current, recording))
+			{
+				await recording.Finalizer.FinalizeAsync(
+					token => FinalizeAsync(deviceId, recording, token),
+					CancellationToken.None).ConfigureAwait(false);
+			}
 		}
 		catch (OperationCanceledException) when (recording.TimeoutCancellation.IsCancellationRequested)
 		{
 		}
 		catch (Exception exception)
 		{
-			Trace.TraceError("Timed recording stop failed for {0}: {1}", deviceId, exception);
+			Trace.TraceError("Timed recording finalization failed for {0}: {1}", deviceId, exception);
 		}
 	}
+
+	private static void ValidateRecording(string path)
+	{
+		if (!File.Exists(path) || new FileInfo(path).Length == 0)
+			throw new InvalidOperationException($"The finalized recording '{path}' is empty or missing.");
+	}
+
+	private static string CreateTemporaryPath(string outputPath) =>
+		Path.Combine(
+			Path.GetDirectoryName(outputPath)!,
+			$".{Path.GetFileName(outputPath)}.{Guid.NewGuid():N}.partial");
 
 	private static string CreateDefaultPath()
 	{
@@ -178,16 +251,66 @@ internal sealed class IosRecordingManager(IProcessRunner processRunner) : IAsync
 	};
 
 	private sealed class ActiveRecording(
-		Process process,
+		IRecordingProcess process,
+		string temporaryPath,
 		string outputPath,
 		DateTimeOffset startedAt,
 		int timeoutSeconds)
 	{
-		public Process Process { get; } = process;
+		public IRecordingProcess Process { get; } = process;
+		public string TemporaryPath { get; } = temporaryPath;
 		public string OutputPath { get; } = outputPath;
 		public DateTimeOffset StartedAt { get; } = startedAt;
 		public int TimeoutSeconds { get; } = timeoutSeconds;
 		public CancellationTokenSource TimeoutCancellation { get; } = new();
+		public RecordingFinalizer Finalizer { get; } = new();
+		public bool StopSignalSent { get; set; }
 		public Task? TimeoutTask { get; set; }
+	}
+}
+
+internal interface IIosRecordingPlatform
+{
+	IRecordingProcess StartRecording(string udid, string outputPath);
+	Task SendInterruptAsync(int processId, CancellationToken cancellationToken);
+}
+
+internal sealed class IosRecordingPlatform(IProcessRunner processRunner) : IIosRecordingPlatform
+{
+	public IRecordingProcess StartRecording(string udid, string outputPath)
+	{
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = "xcrun",
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true,
+		};
+		foreach (var argument in new[]
+		{
+			"simctl", "io", udid, "recordVideo", "--codec=h264", "--force", outputPath,
+		})
+		{
+			startInfo.ArgumentList.Add(argument);
+		}
+
+		var process = Process.Start(startInfo)
+			?? throw new InvalidOperationException("Failed to start simctl screen recording.");
+		process.OutputDataReceived += (_, _) => { };
+		process.ErrorDataReceived += (_, _) => { };
+		process.BeginOutputReadLine();
+		process.BeginErrorReadLine();
+		return new SystemRecordingProcess(process);
+	}
+
+	public async Task SendInterruptAsync(int processId, CancellationToken cancellationToken)
+	{
+		var arguments = new[] { "-INT", processId.ToString() };
+		var result = await processRunner.RunAsync(
+			new ProcessRequest("kill", arguments),
+			cancellationToken).ConfigureAwait(false);
+		if (result.ExitCode != 0)
+			throw new ProcessExecutionException("kill", arguments, result);
 	}
 }

--- a/src/MobileCanvas.iOS/IosSimulatorBackend.cs
+++ b/src/MobileCanvas.iOS/IosSimulatorBackend.cs
@@ -221,6 +221,7 @@ public sealed class IosSimulatorBackend : IDeviceBackend, IAsyncDisposable
 	{
 		InvalidateBootedCache(deviceId);
 		var nativeId = DeviceIdentity.GetNativeId(deviceId);
+		await _recordings.FinalizeOrAbandonAsync(deviceId).ConfigureAwait(false);
 		try
 		{
 			var device = await GetDeviceAsync(deviceId, cancellationToken).ConfigureAwait(false);

--- a/tests/MobileCanvas.Tests/AndroidRecordingManagerTests.cs
+++ b/tests/MobileCanvas.Tests/AndroidRecordingManagerTests.cs
@@ -1,0 +1,332 @@
+using MobileCanvas.Android;
+using MobileCanvas.Contracts;
+using MobileCanvas.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MobileCanvas.Tests;
+
+public sealed class AndroidRecordingManagerTests
+{
+	private const string DeviceId = "android:test";
+
+	[Fact]
+	public async Task ConcurrentStopsShareOneFinalization()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.BlockPull();
+		await fixture.StartAsync();
+
+		var first = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		await fixture.Platform.PullStarted.Task;
+		var second = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		fixture.Platform.ReleasePull();
+
+		var results = await Task.WhenAll(first, second);
+
+		Assert.Same(results[0], results[1]);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(1, fixture.Platform.PullCalls);
+	}
+
+	[Fact]
+	public async Task FailedPullRetainsOwnershipForRetry()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.FailPullAttempts = 1;
+		await fixture.StartAsync();
+
+		await Assert.ThrowsAsync<IOException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+
+		Assert.True(fixture.Manager.GetStatus(DeviceId).IsRecording);
+		Assert.Equal(0, fixture.Platform.RemoveCalls);
+		Assert.Equal(0, fixture.Platform.Process.DisposeCalls);
+
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(2, fixture.Platform.PullCalls);
+		Assert.Equal(1, fixture.Platform.RemoveCalls);
+		Assert.Equal(1, fixture.Platform.Process.DisposeCalls);
+	}
+
+	[Fact]
+	public async Task FailedInterruptIsRetried()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.FailInterruptAttempts = 1;
+		await fixture.StartAsync();
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+
+		Assert.True(fixture.Manager.GetStatus(DeviceId).IsRecording);
+		Assert.Equal(0, fixture.Platform.Process.DisposeCalls);
+
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(2, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task TimeoutJoinsManualStop()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		await fixture.StartAsync();
+
+		fixture.TimeoutDelay.Fire();
+		await fixture.Platform.Process.InterruptObserved.Task;
+		var manualStop = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		fixture.Platform.Process.Exit();
+
+		var completed = await manualStop;
+		await fixture.Platform.PullStarted.Task;
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(1, fixture.Platform.PullCalls);
+	}
+
+	[Fact]
+	public async Task RepeatStopReturnsCachedCompletedStatus()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		await fixture.StartAsync();
+
+		var first = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		var second = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.Same(first, second);
+		Assert.Same(first, fixture.Manager.GetStatus(DeviceId));
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(1, fixture.Platform.PullCalls);
+	}
+
+	[Fact]
+	public async Task CallerCancellationDoesNotCancelSharedFinalization()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		await fixture.StartAsync();
+		using var cancellation = new CancellationTokenSource();
+
+		var canceledWaiter = fixture.Manager.StopAsync(DeviceId, cancellation.Token);
+		await fixture.Platform.Process.InterruptObserved.Task;
+		cancellation.Cancel();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWaiter);
+
+		fixture.Platform.Process.Exit();
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(1, fixture.Platform.PullCalls);
+	}
+
+	[Fact]
+	public async Task ExplicitAbandonCleansFailedFinalization()
+	{
+		using var fixture = new AndroidRecordingFixture();
+		fixture.Platform.BlockPull();
+		fixture.Platform.WriteBeforePullGate = true;
+		fixture.Platform.WriteEmptyPull = true;
+		await fixture.StartAsync();
+
+		var finalization = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		await fixture.Platform.PullStarted.Task;
+		Assert.Single(Directory.GetFiles(fixture.Directory.FullName, "*.partial"));
+
+		await fixture.Manager.AbandonAsync(DeviceId);
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => finalization);
+
+		Assert.Empty(Directory.GetFiles(fixture.Directory.FullName, "*.partial"));
+		Assert.Equal(1, fixture.Platform.RemoveCalls);
+		Assert.Equal(1, fixture.Platform.Process.DisposeCalls);
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+	}
+
+	private sealed class AndroidRecordingFixture : IDisposable
+	{
+		public AndroidRecordingFixture()
+		{
+			Directory = System.IO.Directory.CreateTempSubdirectory("mobile-canvas-android-recording-tests-");
+			TimeoutDelay = new ControlledTimeoutDelay();
+			Platform = new FakeAndroidRecordingPlatform();
+			Manager = new AndroidRecordingManager(
+				Platform,
+				NullLogger.Instance,
+				TimeoutDelay.DelayAsync,
+				TimeSpan.FromSeconds(1));
+		}
+
+		public DirectoryInfo Directory { get; }
+		public ControlledTimeoutDelay TimeoutDelay { get; }
+		public FakeAndroidRecordingPlatform Platform { get; }
+		public AndroidRecordingManager Manager { get; }
+
+		public Task<RecordingStatus> StartAsync() =>
+			Manager.StartAsync(
+				DeviceId,
+				new RecordingStartRequest
+				{
+					OutputPath = Path.Combine(Directory.FullName, "recording.mp4"),
+					TimeoutSeconds = 10,
+				},
+				CancellationToken.None);
+
+		public void Dispose()
+		{
+			Platform.ReleasePull();
+			Manager.DisposeAsync().AsTask().GetAwaiter().GetResult();
+			Directory.Delete(recursive: true);
+		}
+	}
+
+	private sealed class FakeAndroidRecordingPlatform : IAndroidRecordingPlatform
+	{
+		private TaskCompletionSource _pullGate = CompletedGate();
+
+		public FakeRecordingProcess Process { get; } = new();
+		public TaskCompletionSource PullStarted { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		public int FailPullAttempts;
+		public int FailInterruptAttempts;
+		public bool WriteBeforePullGate { get; set; }
+		public bool WriteEmptyPull { get; set; }
+		public int InterruptCalls { get; private set; }
+		public int PullCalls { get; private set; }
+		public int RemoveCalls { get; private set; }
+
+		public void BlockPull() =>
+			_pullGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public void ReleasePull() => _pullGate.TrySetResult();
+
+		public Task<string> RequireSerialAsync(string deviceId, CancellationToken cancellationToken) =>
+			Task.FromResult("emulator-5554");
+
+		public Task<(int Width, int Height)> GetDisplaySizeAsync(
+			string deviceId,
+			CancellationToken cancellationToken) =>
+			Task.FromResult((1080, 1920));
+
+		public IRecordingProcess StartScreenRecord(
+			string serial,
+			string devicePath,
+			int timeoutSeconds,
+			(int Width, int Height)? size) =>
+			Process;
+
+		public async Task<string?> RunAdbAsync(
+			string serial,
+			IReadOnlyList<string> arguments,
+			CancellationToken cancellationToken)
+		{
+			if (arguments.Count >= 2 && arguments[0] == "shell" && arguments[1] == "pkill")
+			{
+				InterruptCalls++;
+				if (Interlocked.Decrement(ref FailInterruptAttempts) >= 0)
+					return null;
+				Process.ObserveInterrupt();
+				return "";
+			}
+
+			if (arguments.Count >= 2 && arguments[0] == "shell" && arguments[1] == "stat")
+				return "128";
+
+			if (arguments.Count >= 1 && arguments[0] == "pull")
+			{
+				PullCalls++;
+				if (WriteBeforePullGate)
+				await WritePullFileAsync(arguments[2], cancellationToken);
+				PullStarted.TrySetResult();
+				await _pullGate.Task.WaitAsync(cancellationToken);
+				if (Interlocked.Decrement(ref FailPullAttempts) >= 0)
+					throw new IOException("adb pull failed");
+
+				if (!WriteBeforePullGate)
+					await WritePullFileAsync(arguments[2], cancellationToken);
+				return "1 file pulled";
+			}
+
+			if (arguments.Count >= 2 && arguments[0] == "shell" && arguments[1] == "rm")
+			{
+				RemoveCalls++;
+				return "";
+			}
+
+			throw new InvalidOperationException($"Unexpected adb arguments: {string.Join(' ', arguments)}");
+		}
+
+		private Task WritePullFileAsync(string path, CancellationToken cancellationToken) =>
+			File.WriteAllBytesAsync(path, WriteEmptyPull ? [] : [1, 2, 3], cancellationToken);
+
+		private static TaskCompletionSource CompletedGate()
+		{
+			var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			gate.SetResult();
+			return gate;
+		}
+	}
+
+	private sealed class ControlledTimeoutDelay
+	{
+		private readonly TaskCompletionSource _timeout =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+		{
+			if (delay == TimeSpan.FromSeconds(10))
+				return _timeout.Task.WaitAsync(cancellationToken);
+			return Task.CompletedTask;
+		}
+
+		public void Fire() => _timeout.TrySetResult();
+	}
+
+	private sealed class FakeRecordingProcess : IRecordingProcess
+	{
+		private readonly TaskCompletionSource _exit =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private volatile bool _hasExited;
+
+		public bool AutoExitOnInterrupt { get; set; } = true;
+		public TaskCompletionSource InterruptObserved { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		public bool HasExited => _hasExited;
+		public int ExitCode => 0;
+		public int Id => 42;
+		public int DisposeCalls { get; private set; }
+		public int KillCalls { get; private set; }
+
+		public void ObserveInterrupt()
+		{
+			InterruptObserved.TrySetResult();
+			if (AutoExitOnInterrupt)
+				Exit();
+		}
+
+		public void Exit()
+		{
+			_hasExited = true;
+			_exit.TrySetResult();
+		}
+
+		public void Dispose() => DisposeCalls++;
+
+		public void Kill()
+		{
+			KillCalls++;
+			Exit();
+		}
+
+		public Task<string> ReadStandardErrorAsync() => Task.FromResult("");
+
+		public Task WaitForExitAsync(CancellationToken cancellationToken) =>
+			_exit.Task.WaitAsync(cancellationToken);
+	}
+}

--- a/tests/MobileCanvas.Tests/IosRecordingManagerTests.cs
+++ b/tests/MobileCanvas.Tests/IosRecordingManagerTests.cs
@@ -1,0 +1,270 @@
+using MobileCanvas.Contracts;
+using MobileCanvas.Core;
+using MobileCanvas.iOS;
+
+namespace MobileCanvas.Tests;
+
+public sealed class IosRecordingManagerTests
+{
+	private const string DeviceId = "ios:test";
+
+	[Fact]
+	public async Task ConcurrentStopsShareOneFinalization()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		await fixture.StartAsync();
+
+		var first = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		await fixture.Platform.Process.InterruptObserved.Task;
+		var second = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		fixture.Platform.CompleteRecording();
+
+		var results = await Task.WhenAll(first, second);
+
+		Assert.Same(results[0], results[1]);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task FailedValidationRetainsOwnershipForRetry()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.WriteFileOnInterrupt = false;
+		await fixture.StartAsync();
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+
+		Assert.True(fixture.Manager.GetStatus(DeviceId).IsRecording);
+		Assert.Equal(0, fixture.Platform.Process.DisposeCalls);
+		fixture.Platform.WriteRecordingFile();
+
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+		Assert.Equal(1, fixture.Platform.Process.DisposeCalls);
+	}
+
+	[Fact]
+	public async Task FailedInterruptIsRetried()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.FailInterruptAttempts = 1;
+		await fixture.StartAsync();
+
+		await Assert.ThrowsAsync<IOException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+
+		Assert.True(fixture.Manager.GetStatus(DeviceId).IsRecording);
+		Assert.Equal(0, fixture.Platform.Process.DisposeCalls);
+
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(2, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task TimeoutJoinsManualStop()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		await fixture.StartAsync();
+
+		fixture.TimeoutDelay.Fire();
+		await fixture.Platform.Process.InterruptObserved.Task;
+		var manualStop = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		fixture.Platform.CompleteRecording();
+
+		var completed = await manualStop;
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task RepeatStopReturnsCachedCompletedStatus()
+	{
+		using var fixture = new IosRecordingFixture();
+		await fixture.StartAsync();
+
+		var first = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		var second = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.Same(first, second);
+		Assert.Same(first, fixture.Manager.GetStatus(DeviceId));
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task CallerCancellationDoesNotCancelSharedFinalization()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		await fixture.StartAsync();
+		using var cancellation = new CancellationTokenSource();
+
+		var canceledWaiter = fixture.Manager.StopAsync(DeviceId, cancellation.Token);
+		await fixture.Platform.Process.InterruptObserved.Task;
+		cancellation.Cancel();
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWaiter);
+
+		fixture.Platform.CompleteRecording();
+		var completed = await fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+
+		Assert.False(completed.IsRecording);
+		Assert.Equal(1, fixture.Platform.InterruptCalls);
+	}
+
+	[Fact]
+	public async Task ExplicitAbandonCleansFailedFinalization()
+	{
+		using var fixture = new IosRecordingFixture();
+		fixture.Platform.Process.AutoExitOnInterrupt = false;
+		fixture.Platform.WriteEmptyFileOnInterrupt = true;
+		await fixture.StartAsync();
+
+		var finalization = fixture.Manager.StopAsync(DeviceId, CancellationToken.None);
+		await fixture.Platform.Process.InterruptObserved.Task;
+		Assert.True(File.Exists(fixture.Platform.OutputPath));
+
+		await fixture.Manager.AbandonAsync(DeviceId);
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => finalization);
+
+		Assert.False(File.Exists(fixture.Platform.OutputPath));
+		Assert.Equal(1, fixture.Platform.Process.DisposeCalls);
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => fixture.Manager.StopAsync(DeviceId, CancellationToken.None));
+	}
+
+	private sealed class IosRecordingFixture : IDisposable
+	{
+		public IosRecordingFixture()
+		{
+			Directory = System.IO.Directory.CreateTempSubdirectory("mobile-canvas-ios-recording-tests-");
+			TimeoutDelay = new ControlledTimeoutDelay();
+			Platform = new FakeIosRecordingPlatform();
+			Manager = new IosRecordingManager(
+				Platform,
+				TimeoutDelay.DelayAsync,
+				TimeSpan.FromSeconds(1));
+		}
+
+		public DirectoryInfo Directory { get; }
+		public ControlledTimeoutDelay TimeoutDelay { get; }
+		public FakeIosRecordingPlatform Platform { get; }
+		public IosRecordingManager Manager { get; }
+
+		public Task<RecordingStatus> StartAsync() =>
+			Manager.StartAsync(
+				DeviceId,
+				"test-udid",
+				new RecordingStartRequest
+				{
+					OutputPath = Path.Combine(Directory.FullName, "recording.mp4"),
+					TimeoutSeconds = 10,
+				},
+				CancellationToken.None);
+
+		public void Dispose()
+		{
+			Manager.DisposeAsync().AsTask().GetAwaiter().GetResult();
+			Directory.Delete(recursive: true);
+		}
+	}
+
+	private sealed class FakeIosRecordingPlatform : IIosRecordingPlatform
+	{
+		public FakeRecordingProcess Process { get; } = new();
+		public string OutputPath { get; private set; } = "";
+		public bool WriteFileOnInterrupt { get; set; } = true;
+		public bool WriteEmptyFileOnInterrupt { get; set; }
+		public int FailInterruptAttempts;
+		public int InterruptCalls { get; private set; }
+
+		public IRecordingProcess StartRecording(string udid, string outputPath)
+		{
+			OutputPath = outputPath;
+			return Process;
+		}
+
+		public Task SendInterruptAsync(int processId, CancellationToken cancellationToken)
+		{
+			InterruptCalls++;
+			if (Interlocked.Decrement(ref FailInterruptAttempts) >= 0)
+				throw new IOException("kill failed");
+			if (WriteFileOnInterrupt)
+				WriteRecordingFile();
+			Process.ObserveInterrupt();
+			return Task.CompletedTask;
+		}
+
+		public void CompleteRecording()
+		{
+			WriteRecordingFile();
+			Process.Exit();
+		}
+
+		public void WriteRecordingFile() =>
+			File.WriteAllBytes(OutputPath, WriteEmptyFileOnInterrupt ? [] : [1, 2, 3]);
+	}
+
+	private sealed class ControlledTimeoutDelay
+	{
+		private readonly TaskCompletionSource _timeout =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+		{
+			if (delay == TimeSpan.FromSeconds(10))
+				return _timeout.Task.WaitAsync(cancellationToken);
+			return Task.CompletedTask;
+		}
+
+		public void Fire() => _timeout.TrySetResult();
+	}
+
+	private sealed class FakeRecordingProcess : IRecordingProcess
+	{
+		private readonly TaskCompletionSource _exit =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private volatile bool _hasExited;
+
+		public bool AutoExitOnInterrupt { get; set; } = true;
+		public TaskCompletionSource InterruptObserved { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		public bool HasExited => _hasExited;
+		public int ExitCode => 0;
+		public int Id => 43;
+		public int DisposeCalls { get; private set; }
+		public int KillCalls { get; private set; }
+
+		public void ObserveInterrupt()
+		{
+			InterruptObserved.TrySetResult();
+			if (AutoExitOnInterrupt)
+				Exit();
+		}
+
+		public void Exit()
+		{
+			_hasExited = true;
+			_exit.TrySetResult();
+		}
+
+		public void Dispose() => DisposeCalls++;
+
+		public void Kill()
+		{
+			KillCalls++;
+			Exit();
+		}
+
+		public Task<string> ReadStandardErrorAsync() => Task.FromResult("");
+
+		public Task WaitForExitAsync(CancellationToken cancellationToken) =>
+			_exit.Task.WaitAsync(cancellationToken);
+	}
+}


### PR DESCRIPTION
## Summary

- serialize Android and iOS recording finalization per device and share one retryable finalization task across manual and timeout callers
- preserve native process, device-file, and temporary-file ownership after interrupt, wait, flush, pull, copy, or validation failures
- isolate caller cancellation from shared finalization, cache completed status only after success, and return it idempotently on repeated stops
- add explicit finalize-or-abandon cleanup before destructive backend shutdown/disposal
- stage both platforms into managed temporary files and publish output only after non-empty validation
- point the runtime manifest at `v0.1.18-rc.2`, built from this managed source
- make the explicit-abandon test seam deterministic by publishing the pull checkpoint only after its partial file exists and always releasing the fake transport during fixture cleanup

## Tests

- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --no-restore --filter 'FullyQualifiedName~AndroidRecordingManagerTests|FullyQualifiedName~IosRecordingManagerTests' --logger 'console;verbosity=minimal'` — 14 passed
- `dotnet test tests/MobileCanvas.Tests/MobileCanvas.Tests.csproj --no-restore --logger 'console;verbosity=minimal'` — 407 passed
- 100 consecutive Release-mode runs of `AndroidRecordingManagerTests.ExplicitAbandonCleansFailedFinalization` with a 5-second hang detector — passed
- `node scripts/source-hash.mjs --check` — published runtime source matches (130 files)
- blocker-only code review — no findings after fixes
- GitHub CI — passed

## Stack / PR #93 overlap

- direct parent/base: `redth-backend-lifecycle-fixes` / #93 at `6f5ddab4bcb4dfb2f31b99073be4518c9d9889d9`
- preserves #93's Android shutdown bounds/cancellation, iOS orientation cache changes, and `v0.1.18-rc.1` runtime refresh
- the production recording-finalization delta is byte-for-byte unchanged by the restack (`c597ea9a83e45864fbb35620fabe73e80dd54f43` stable patch ID for `src/`)
- overlaps only the two backend files: one Android shutdown call is upgraded to finalize-or-abandon, and one iOS shutdown call is added before `simctl shutdown`; #93's test files are untouched

## Runtime / Ailoha source export

- published `v0.1.18-rc.2` runtime assets from this source and refreshed only `runtimes/manifest.json`; native source and `mobile-screencap` bytes are unchanged
- when composed with #85, `git ls-files` adds three managed/test source entries and refreshes hashes for five existing managed files plus the runtime manifest; the aggregate Ailoha snapshot hash and runtime asset hashes change